### PR TITLE
Enforce frontmatter name matches slug at publish and upload

### DIFF
--- a/cli/src/strawhub/commands/publish.py
+++ b/cli/src/strawhub/commands/publish.py
@@ -6,7 +6,7 @@ import click
 from strawhub.client import StrawHubClient
 from strawhub.display import print_success, print_error, console
 from strawhub.errors import StrawHubError
-from strawhub.frontmatter import parse_frontmatter, extract_dependencies
+from strawhub.frontmatter import parse_frontmatter, extract_dependencies, rewrite_frontmatter_name
 
 
 @click.group(invoke_without_command=True)
@@ -39,6 +39,13 @@ def _publish_impl(path, kind, ver, changelog, tags):
         )
         raise SystemExit(1)
 
+    # Ensure frontmatter name matches the slug
+    name_rewritten = False
+    fm_name = fm.get("name")
+    if fm_name != slug:
+        content = rewrite_frontmatter_name(content, slug)
+        name_rewritten = True
+
     display_name = fm.get("displayName") or fm.get("display_name") or slug
     version = ver or fm.get("version")
     if not version:
@@ -61,6 +68,19 @@ def _publish_impl(path, kind, ver, changelog, tags):
     if not files:
         print_error("No files found in directory.")
         raise SystemExit(1)
+
+    # Patch the main file in-memory if name was rewritten
+    if name_rewritten:
+        patched = content.encode("utf-8")
+        files = [
+            ("files", (main_file, patched, "text/markdown"))
+            if name == main_file
+            else (key, (name, data, ct))
+            for key, (name, data, ct) in files
+        ]
+        console.print(
+            f"  [dim]Updated frontmatter name to match slug '{slug}'[/dim]"
+        )
 
     console.print(f"Publishing {kind} '{slug}' v{version}...")
     console.print(f"  Files: {len(files)}")

--- a/cli/src/strawhub/frontmatter.py
+++ b/cli/src/strawhub/frontmatter.py
@@ -170,6 +170,32 @@ def _parse_array(
     return result, i
 
 
+def rewrite_frontmatter_name(text: str, new_name: str) -> str:
+    """Rewrite the ``name`` field in YAML frontmatter.
+
+    If the frontmatter contains a ``name:`` line, its value is replaced
+    with *new_name*.  If no ``name:`` line exists, one is inserted as the
+    first line of the frontmatter block.
+
+    Returns the full text with the updated frontmatter.
+    """
+    m = re.match(r"^---\s*\n([\s\S]*?\n)---\s*\n([\s\S]*)$", text)
+    if not m:
+        return text
+
+    yaml_str = m.group(1)
+    body = m.group(2)
+
+    if re.search(r"^name:\s*.*$", yaml_str, re.MULTILINE):
+        yaml_str = re.sub(
+            r"^name:\s*.*$", f"name: {new_name}", yaml_str, count=1, flags=re.MULTILINE
+        )
+    else:
+        yaml_str = f"name: {new_name}\n" + yaml_str
+
+    return f"---\n{yaml_str}---\n{body}"
+
+
 def extract_dependencies(
     fm: dict, kind: str
 ) -> dict | None:

--- a/cli/tests/test_frontmatter.py
+++ b/cli/tests/test_frontmatter.py
@@ -1,6 +1,6 @@
 """Tests for frontmatter.py — ported from convex/lib/frontmatter.test.ts."""
 
-from strawhub.frontmatter import parse_frontmatter, extract_dependencies
+from strawhub.frontmatter import parse_frontmatter, extract_dependencies, rewrite_frontmatter_name
 
 
 class TestParseFrontmatter:
@@ -231,3 +231,51 @@ class TestExtractDependencies:
     def test_returns_none_when_no_dependencies(self):
         fm = {"metadata": {"strawpot": {"other": "value"}}}
         assert extract_dependencies(fm, "skill") is None
+
+
+class TestRewriteFrontmatterName:
+    def test_replaces_existing_name(self):
+        text = '---\nname: old-name\ndescription: "A skill"\n---\nBody.\n'
+        result = rewrite_frontmatter_name(text, "new-name")
+        parsed = parse_frontmatter(result)
+        assert parsed["frontmatter"]["name"] == "new-name"
+        assert parsed["frontmatter"]["description"] == "A skill"
+        assert parsed["body"] == "Body.\n"
+
+    def test_inserts_name_when_missing(self):
+        text = '---\ndescription: "A skill"\n---\nBody.\n'
+        result = rewrite_frontmatter_name(text, "my-skill")
+        parsed = parse_frontmatter(result)
+        assert parsed["frontmatter"]["name"] == "my-skill"
+        assert parsed["frontmatter"]["description"] == "A skill"
+
+    def test_preserves_body(self):
+        text = "---\nname: old\n---\n# Hello\n\nWorld\n"
+        result = rewrite_frontmatter_name(text, "new")
+        parsed = parse_frontmatter(result)
+        assert parsed["frontmatter"]["name"] == "new"
+        assert "# Hello" in parsed["body"]
+        assert "World" in parsed["body"]
+
+    def test_no_frontmatter_returns_unchanged(self):
+        text = "Just plain markdown."
+        result = rewrite_frontmatter_name(text, "new-name")
+        assert result == text
+
+    def test_preserves_other_fields(self):
+        text = (
+            "---\n"
+            "name: old\n"
+            "description: test\n"
+            "metadata:\n"
+            "  strawpot:\n"
+            "    dependencies:\n"
+            "      - dep-a\n"
+            "---\n"
+            "Body.\n"
+        )
+        result = rewrite_frontmatter_name(text, "new")
+        parsed = parse_frontmatter(result)
+        assert parsed["frontmatter"]["name"] == "new"
+        assert parsed["frontmatter"]["description"] == "test"
+        assert parsed["frontmatter"]["metadata"]["strawpot"]["dependencies"] == ["dep-a"]

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -3,6 +3,7 @@ import { api, internal } from "../_generated/api";
 import { jsonResponse, errorResponse, getSearchParams, resolveTokenToUser, checkHttpRateLimit } from "./shared";
 import { parseDependencySpec, satisfiesVersion } from "../lib/versionSpec";
 import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateRoleFiles, assertRoleFileIsText, MAX_FILE_SIZE } from "../lib/publishValidation";
+import { parseFrontmatter, extractName } from "../lib/frontmatter";
 import { createZipBlob } from "../lib/zip";
 
 /**
@@ -310,6 +311,18 @@ export const publishRole = httpAction(async (ctx, request) => {
 
   if (fileEntries.length === 0) {
     return errorResponse("At least one file is required", 400);
+  }
+
+  // Validate frontmatter name matches slug
+  if (roleMdText) {
+    const { frontmatter } = parseFrontmatter(roleMdText);
+    const fmName = extractName(frontmatter);
+    if (fmName && fmName !== slug) {
+      return errorResponse(
+        `Frontmatter name '${fmName}' does not match slug '${slug}'`,
+        400,
+      );
+    }
   }
 
   try {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -2,6 +2,7 @@ import { httpAction } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import { jsonResponse, errorResponse, getSearchParams, resolveTokenToUser, hashToken, checkHttpRateLimit } from "./shared";
 import { validateSlug, validateVersion, validateDisplayName, validateChangelog, MAX_FILE_SIZE } from "../lib/publishValidation";
+import { parseFrontmatter, extractName } from "../lib/frontmatter";
 import { createZipBlob } from "../lib/zip";
 
 /**
@@ -174,6 +175,18 @@ export const publishSkill = httpAction(async (ctx, request) => {
 
   if (fileEntries.length === 0) {
     return errorResponse("At least one file is required", 400);
+  }
+
+  // Validate frontmatter name matches slug
+  if (skillMdText) {
+    const { frontmatter } = parseFrontmatter(skillMdText);
+    const fmName = extractName(frontmatter);
+    if (fmName && fmName !== slug) {
+      return errorResponse(
+        `Frontmatter name '${fmName}' does not match slug '${slug}'`,
+        400,
+      );
+    }
   }
 
   // Create and store zip archive

--- a/convex/lib/frontmatter.ts
+++ b/convex/lib/frontmatter.ts
@@ -170,6 +170,14 @@ function parseArray(
 }
 
 /**
+ * Extract the ``name`` field from parsed frontmatter.
+ */
+export function extractName(fm: Record<string, unknown>): string | undefined {
+  const name = fm.name;
+  return typeof name === "string" ? name : undefined;
+}
+
+/**
  * Extract dependencies from parsed frontmatter.
  *
  * Reads from metadata.strawpot.dependencies.


### PR DESCRIPTION
## Summary

- CLI (`publish.py`): rewrite `name` field in-memory before upload if it doesn't match the slug; print a notice to the author
- Server (`skillsV1.ts`, `rolesV1.ts`): reject uploads where frontmatter `name` differs from the `slug` form field (400 error)
- Add `rewrite_frontmatter_name()` utility in `frontmatter.py` for regex-based name replacement
- Add `extractName()` helper in `frontmatter.ts` for server-side name extraction
- Companion to strawpot PR that validates slug-name consistency at load time

## Test plan

- [x] New tests in `test_frontmatter.py`: replaces existing name, inserts when missing, preserves body, no-op without frontmatter, preserves other fields
- [x] Full frontmatter test suite passes (29 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)