### PR TITLE
Add E2E tests for listing pages and search page

### DIFF
--- a/e2e/listing.pw.test.ts
+++ b/e2e/listing.pw.test.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Skills listing page", () => {
+  test("renders heading and description", async ({ page }) => {
+    await page.goto("/skills");
+    await expect(page.locator("h1")).toContainText("Skills");
+    await expect(
+      page.locator(
+        "text=Markdown instruction modules that agents load into context.",
+      ),
+    ).toBeVisible();
+  });
+
+  test("has filter input and publish button", async ({ page }) => {
+    await page.goto("/skills");
+    await expect(
+      page.locator('input[placeholder="Filter by name, slug, or summary..."]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('a:has-text("Publish Skill")'),
+    ).toBeVisible();
+  });
+
+  test("publish button links to upload page", async ({ page }) => {
+    await page.goto("/skills");
+    const publishLink = page.locator('a:has-text("Publish Skill")');
+    await expect(publishLink).toHaveAttribute("href", /\/upload/);
+  });
+});
+
+test.describe("Roles listing page", () => {
+  test("renders heading and description", async ({ page }) => {
+    await page.goto("/roles");
+    await expect(page.locator("h1")).toContainText("Roles");
+    await expect(
+      page.locator(
+        "text=Agent behavior definitions with dependent skills that are resolved recursively on install.",
+      ),
+    ).toBeVisible();
+  });
+
+  test("has filter input and publish button", async ({ page }) => {
+    await page.goto("/roles");
+    await expect(
+      page.locator('input[placeholder="Filter by name, slug, or summary..."]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('a:has-text("Publish Role")'),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Agents listing page", () => {
+  test("renders heading and description", async ({ page }) => {
+    await page.goto("/agents");
+    await expect(page.locator("h1")).toContainText("Agents");
+    await expect(
+      page.getByText(
+        /CLI wrapper binaries that translate StrawPot/,
+      ),
+    ).toBeVisible();
+  });
+
+  test("has filter input and publish button", async ({ page }) => {
+    await page.goto("/agents");
+    await expect(
+      page.locator('input[placeholder="Filter by name, slug, or summary..."]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('a:has-text("Publish Agent")'),
+    ).toBeVisible();
+  });
+});

--- a/e2e/search.pw.test.ts
+++ b/e2e/search.pw.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Search page", () => {
+  test("shows prompt when query is too short", async ({ page }) => {
+    await page.goto("/search");
+    const input = page.locator(
+      'input[placeholder="Search skills and roles..."]',
+    );
+    await input.fill("a");
+    await expect(
+      page.locator("text=Type at least 2 characters to search."),
+    ).toBeVisible();
+  });
+
+  test("has kind filter dropdown with all options", async ({ page }) => {
+    await page.goto("/search");
+    const select = page.locator("select");
+    await expect(select).toBeVisible();
+    await expect(select.locator("option")).toHaveText([
+      "All",
+      "Skills",
+      "Roles",
+      "Agents",
+    ]);
+  });
+
+  test("kind filter can be changed", async ({ page }) => {
+    await page.goto("/search");
+    const select = page.locator("select");
+    await select.selectOption("skill");
+    await expect(select).toHaveValue("skill");
+    await select.selectOption("role");
+    await expect(select).toHaveValue("role");
+    await select.selectOption("agent");
+    await expect(select).toHaveValue("agent");
+    await select.selectOption("all");
+    await expect(select).toHaveValue("all");
+  });
+
+});


### PR DESCRIPTION
## Summary
- Add 10 new Playwright E2E tests covering the public discovery journey
- **Listing pages** (skills, roles, agents): verify heading, description text, filter input, and publish button render correctly
- **Search page**: verify min-length validation prompt, kind filter dropdown has all 4 options, and filter values cycle correctly
- All tests target static UI elements to avoid flakiness from Convex backend availability in the `vite preview` test environment

## Test plan
- [x] All 21 E2E tests pass (`npx playwright test` — 11 existing smoke + 10 new)
- [x] All 180 unit tests pass (`npm run test:ci`)
- [x] No overlap with existing smoke tests (removed one duplicate nav test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)