### PR TITLE
Enforce frontmatter name matches slug in publish mutations

### DIFF
--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -3,7 +3,7 @@ import { mutation, query, internalMutation } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter } from "./lib/frontmatter";
 import { parseVersion, compareVersions } from "./lib/versionSpec";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles, validateFrontmatterName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -189,6 +189,7 @@ export const publishInternal = internalMutation({
       const { frontmatter } = parseFrontmatter(args.agentMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     let agent = await ctx.db
       .query("agents")
@@ -289,6 +290,7 @@ export const publish = mutation({
       const { frontmatter } = parseFrontmatter(args.agentMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     // Find or create agent
     let agent = await ctx.db

--- a/convex/lib/publishValidation.test.ts
+++ b/convex/lib/publishValidation.test.ts
@@ -6,6 +6,7 @@ import {
   validateChangelog,
   validateFiles,
   validateRoleFiles,
+  validateFrontmatterName,
   assertRoleFileIsText,
   MAX_SLUG_LENGTH,
   MAX_DISPLAY_NAME_LENGTH,
@@ -190,6 +191,28 @@ describe("validateRoleFiles", () => {
   it("rejects lowercase role.md", () => {
     expect(() => validateRoleFiles([{ path: "role.md", size: 500 }])).toThrow(
       /exactly one file: ROLE.md/,
+    );
+  });
+});
+
+describe("validateFrontmatterName", () => {
+  it("accepts matching name", () => {
+    expect(() => validateFrontmatterName({ name: "my-skill" }, "my-skill")).not.toThrow();
+  });
+
+  it("accepts missing name field", () => {
+    expect(() => validateFrontmatterName({}, "my-skill")).not.toThrow();
+  });
+
+  it("accepts non-string name", () => {
+    expect(() => validateFrontmatterName({ name: 42 }, "my-skill")).not.toThrow();
+    expect(() => validateFrontmatterName({ name: true }, "my-skill")).not.toThrow();
+    expect(() => validateFrontmatterName({ name: null }, "my-skill")).not.toThrow();
+  });
+
+  it("rejects mismatched name", () => {
+    expect(() => validateFrontmatterName({ name: "other-name" }, "my-skill")).toThrow(
+      /Frontmatter name 'other-name' does not match slug 'my-skill'/,
     );
   });
 });

--- a/convex/lib/publishValidation.ts
+++ b/convex/lib/publishValidation.ts
@@ -122,6 +122,21 @@ export function validateRoleFiles(
 }
 
 /**
+ * Validate that the frontmatter `name` field (if present) matches the slug.
+ */
+export function validateFrontmatterName(
+  frontmatter: Record<string, unknown>,
+  slug: string,
+): void {
+  const name = frontmatter.name;
+  if (typeof name === "string" && name !== slug) {
+    throw new Error(
+      `Frontmatter name '${name}' does not match slug '${slug}'`,
+    );
+  }
+}
+
+/**
  * Verify that a ROLE.md file is actually a text file, not a renamed binary.
  * Uses three layers: extension check, magic bytes detection, null byte heuristic.
  */

--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -3,7 +3,7 @@ import { mutation, query, internalMutation } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter, extractDependencies } from "./lib/frontmatter";
 import { parseDependencySpec, parseVersion, compareVersions, satisfiesVersion } from "./lib/versionSpec";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateRoleFiles } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateRoleFiles, validateFrontmatterName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -205,6 +205,7 @@ export const publishInternal = internalMutation({
       const { frontmatter } = parseFrontmatter(args.roleMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     let dependencies = args.dependencies;
     if (!dependencies) {
@@ -381,6 +382,7 @@ export const publish = mutation({
       const { frontmatter } = parseFrontmatter(args.roleMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     // Read dependencies from frontmatter if not provided in args
     let dependencies = args.dependencies;

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4,7 +4,7 @@ import { internal } from "./_generated/api";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter, extractDependencies } from "./lib/frontmatter";
 import { parseDependencySpec, parseVersion, compareVersions, satisfiesVersion } from "./lib/versionSpec";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateFrontmatterName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -222,6 +222,7 @@ export const publishInternal = internalMutation({
       const { frontmatter } = parseFrontmatter(args.skillMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     // Read dependencies from frontmatter if not provided in args
     let dependencies = args.dependencies;
@@ -390,6 +391,7 @@ export const publish = mutation({
       const { frontmatter } = parseFrontmatter(args.skillMdText);
       parsed = { frontmatter, metadata: frontmatter.metadata };
     }
+    validateFrontmatterName(parsed.frontmatter, args.slug);
 
     // Read dependencies from frontmatter if not provided in args
     let dependencies = args.dependencies;


### PR DESCRIPTION
## Summary
- Add `validateFrontmatterName` helper to `convex/lib/publishValidation.ts`
- Call it in all 6 publish mutations (`publish` + `publishInternal` for skills, roles, and agents)
- The HTTP API handlers already had this check; now the Convex mutations enforce it too, closing a bypass path

## Test plan
- [x] 4 new unit tests for `validateFrontmatterName` (matching name, missing name, non-string name, mismatched name)
- [x] All 184 unit tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)