### PR TITLE
Support "*" wildcard in role dependencies

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -109,6 +109,8 @@ metadata:
 ---
 ```
 
+The `roles` list supports `"*"` as a wildcard meaning "all available roles." This is useful for orchestrator roles that can delegate to any installed role. The wildcard is expanded at runtime by StrawPot and filtered out during install (it is not a real package slug).
+
 ```yaml
 # AGENT.md
 ---
@@ -193,7 +195,7 @@ Web UI also supports **GitHub import**: paste a repo URL, files are fetched via 
 
 **Skills** — client-side DFS. The CLI recursively fetches frontmatter for each dependency and builds the transitive list.
 
-**Roles** — server-side topological sort via `GET /api/v1/roles/:slug/resolve`. The server walks both skill and role dependencies, detects cycles, and returns a sorted install order (leaves first).
+**Roles** — server-side topological sort via `GET /api/v1/roles/:slug/resolve`. The server walks both skill and role dependencies, detects cycles, and returns a sorted install order (leaves first). The `"*"` wildcard in the `roles` dependency list is filtered out by the CLI before install — it is not a real dependency but a runtime directive expanded by StrawPot.
 
 ```
 GET /api/v1/roles/implementer/resolve

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Instructions for the agent...
 
 ### ROLE.md
 
-Role dependencies are declared under `metadata.strawpot.dependencies` with `skills` and `roles` sub-keys.
+Role dependencies are declared under `metadata.strawpot.dependencies` with `skills` and `roles` sub-keys. Use `"*"` in the `roles` list to depend on all available roles (useful for orchestrator roles that can delegate to any role).
 
 ```yaml
 ---

--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -582,7 +582,9 @@ def _resolve_deps(
     elif kind == "role":
         console.print("Resolving dependencies...")
         resolved = client.resolve_role_deps(slug)
-        return resolved.get("dependencies", [])
+        deps = resolved.get("dependencies", [])
+        # Filter "*" wildcard — not a real package slug
+        return [d for d in deps if d.get("slug") != "*"]
     else:
         # Skills: resolve client-side via frontmatter parsing
         dep_list: list[dict] = []

--- a/cli/src/strawhub/frontmatter.py
+++ b/cli/src/strawhub/frontmatter.py
@@ -164,7 +164,13 @@ def _parse_array(
         if not trimmed.startswith("- "):
             break
 
-        result.append(trimmed[2:].strip())
+        val = trimmed[2:].strip()
+        # Strip surrounding quotes (consistent with _parse_scalar)
+        if (val.startswith('"') and val.endswith('"')) or (
+            val.startswith("'") and val.endswith("'")
+        ):
+            val = val[1:-1]
+        result.append(val)
         i += 1
 
     return result, i

--- a/cli/src/strawhub/resolver.py
+++ b/cli/src/strawhub/resolver.py
@@ -217,6 +217,8 @@ def _read_dependency_slugs(
         result.append(("skill", extract_slug(spec_str)))
     if kind == "role":
         for spec_str in deps.get("roles", []):
+            if spec_str.strip() == "*":
+                continue  # wildcard — expanded at runtime, not a real dep
             result.append(("role", extract_slug(spec_str)))
 
     return result

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -68,7 +68,10 @@ def make_role(strawpot_dir):
                 dep_section += "".join(f"        - {s}\n" for s in skill_deps)
             if role_deps:
                 dep_section += "      roles:\n"
-                dep_section += "".join(f"        - {r}\n" for r in role_deps)
+                for r in role_deps:
+                    # Quote "*" to avoid YAML alias interpretation
+                    v = f'"{r}"' if r == "*" else r
+                    dep_section += f"        - {v}\n"
 
         (d / "ROLE.md").write_text(
             f"---\nname: {slug}\ndescription: \"{slug} role\"\n{dep_section}---\n\n# {slug}\n"

--- a/cli/tests/test_frontmatter.py
+++ b/cli/tests/test_frontmatter.py
@@ -25,6 +25,15 @@ class TestParseFrontmatter:
             "git-workflow",
         ]
 
+    def test_yaml_list_quoted_items(self):
+        text = "---\ntags:\n  - \"quoted-double\"\n  - 'quoted-single'\n  - bare\n---\nBody.\n"
+        result = parse_frontmatter(text)
+        assert result["frontmatter"]["tags"] == [
+            "quoted-double",
+            "quoted-single",
+            "bare",
+        ]
+
     def test_inline_array(self):
         text = "---\ntags: [testing, ci, quality]\n---\nBody.\n"
         result = parse_frontmatter(text)

--- a/cli/tests/test_install.py
+++ b/cli/tests/test_install.py
@@ -1,0 +1,34 @@
+"""Tests for strawhub.commands.install helpers."""
+
+from unittest.mock import MagicMock
+
+from strawhub.commands.install import _resolve_deps
+
+
+class TestResolveDepsWildcard:
+    def test_filters_wildcard_from_role_deps(self):
+        """'*' slug returned by server is filtered out."""
+        client = MagicMock()
+        client.resolve_role_deps.return_value = {
+            "dependencies": [
+                {"slug": "reviewer", "version": "1.0.0"},
+                {"slug": "*"},
+                {"slug": "implementer", "version": "1.0.0"},
+            ],
+        }
+        result = _resolve_deps(client, "role", "lead", {})
+        slugs = [d["slug"] for d in result]
+        assert "*" not in slugs
+        assert slugs == ["reviewer", "implementer"]
+
+    def test_no_wildcard_passes_through(self):
+        """Normal deps pass through unchanged."""
+        client = MagicMock()
+        client.resolve_role_deps.return_value = {
+            "dependencies": [
+                {"slug": "reviewer", "version": "1.0.0"},
+            ],
+        }
+        result = _resolve_deps(client, "role", "lead", {})
+        assert len(result) == 1
+        assert result[0]["slug"] == "reviewer"

--- a/cli/tests/test_resolver.py
+++ b/cli/tests/test_resolver.py
@@ -231,3 +231,31 @@ class TestResolveRoleDeps:
         dep_slugs = [d["slug"] for d in result["dependencies"]]
         assert dep_slugs.count("d") == 1
         assert set(dep_slugs) == {"b", "c", "d"}
+
+    def test_wildcard_role_dep_ignored(self, strawpot_dir, make_skill, make_role):
+        """'*' in role deps is skipped during resolution."""
+        make_skill("code-review", "1.0.0")
+        make_role("lead", "1.0.0", skill_deps=["code-review"], role_deps=["*"])
+
+        result = resolve(
+            "lead", kind="role",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert "*" not in dep_slugs
+        assert dep_slugs == {"code-review"}
+
+    def test_wildcard_with_explicit_role_dep(self, strawpot_dir, make_skill, make_role):
+        """'*' alongside explicit role deps: explicit deps resolved, '*' skipped."""
+        make_skill("testing", "1.0.0")
+        make_role("reviewer", "1.0.0", skill_deps=["testing"])
+        make_role("lead", "1.0.0", role_deps=["reviewer", "*"])
+
+        result = resolve(
+            "lead", kind="role",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert "*" not in dep_slugs
+        assert "reviewer" in dep_slugs
+        assert "testing" in dep_slugs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,7 +105,7 @@ Installs a skill or role from the StrawHub registry. Dependencies are resolved a
 **Dependency resolution:**
 
 - **Skills**: Client-side resolution. Recursively fetches `SKILL.md` frontmatter from the registry, reads `metadata.strawpot.dependencies`, and performs a DFS to build a transitive dependency list (leaves first).
-- **Roles**: Server-side resolution. Calls the `/api/v1/roles/<slug>/resolve` endpoint, which returns a topologically sorted list of all transitive skill and role dependencies.
+- **Roles**: Server-side resolution. Calls the `/api/v1/roles/<slug>/resolve` endpoint, which returns a topologically sorted list of all transitive skill and role dependencies. The `"*"` wildcard in role dependencies is filtered out — it is not a real package slug but a runtime directive expanded by StrawPot.
 
 After installation, system tool requirements declared in `metadata.strawpot.tools` are checked and install commands are run for missing tools (unless `--skip-tools`).
 

--- a/docs/content-format.md
+++ b/docs/content-format.md
@@ -84,7 +84,7 @@ Role instructions for the agent...
 | `description` | Yes | One-line summary |
 | `version` | No | Semver version (auto-incremented if omitted) |
 | `metadata.strawpot.dependencies.skills` | No | List of skill slugs |
-| `metadata.strawpot.dependencies.roles` | No | List of role slugs |
+| `metadata.strawpot.dependencies.roles` | No | List of role slugs (use `"*"` for all available roles) |
 | `metadata.strawpot.default_agent` | No | Default agent runtime name |
 
 Roles can depend on both skills and other roles.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -98,7 +98,7 @@ Content-Type: multipart/form-data
 payload: { slug, displayName, version, changelog, dependencies?, customTags?, files[] }
 ```
 
-The `dependencies` field is optional JSON: `{"skills": ["git-workflow>=1.0.0", "code-review"], "roles": ["reviewer"]}`. If omitted, dependencies are read from `metadata.strawpot.dependencies` in the ROLE.md frontmatter.
+The `dependencies` field is optional JSON: `{"skills": ["git-workflow>=1.0.0", "code-review"], "roles": ["reviewer"]}`. If omitted, dependencies are read from `metadata.strawpot.dependencies` in the ROLE.md frontmatter. The `roles` list supports `"*"` as a wildcard meaning "all available roles" — this is stored as-is and expanded at runtime by StrawPot.
 
 Roles must contain exactly one file named `ROLE.md`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -95,7 +95,7 @@ metadata:
 
 ## Dependencies
 
-Dependencies are declared under `metadata.strawpot.dependencies`. Skills use a flat list of slugs (skills can only depend on other skills). Roles use a structured object with `skills` and `roles` sub-keys.
+Dependencies are declared under `metadata.strawpot.dependencies`. Skills use a flat list of slugs (skills can only depend on other skills). Roles use a structured object with `skills` and `roles` sub-keys. The `roles` list supports `"*"` as a wildcard meaning "all available roles" — this is expanded at runtime by StrawPot and filtered out during install.
 
 ## System Tools
 


### PR DESCRIPTION
## Summary

- Filter `"*"` wildcard from role dependency resolution and install so it's not treated as a real package slug
- Fix `_parse_array` in frontmatter parser to strip quotes from YAML block-list items (e.g., `- "*"` was returned as `"*"` with literal quotes)
- Add tests for wildcard filtering in resolver, install, and frontmatter
- Update docs (README, DESIGN, spec, http-api, cli, content-format) to document wildcard behavior

## Test plan

- [x] All 203 CLI tests pass (`cd cli && python -m pytest tests/ -v`)
- [x] `_read_dependency_slugs` skips `"*"` in role deps
- [x] `_resolve_deps` filters `"*"` from server-returned dep list
- [x] `_parse_array` strips quotes from block-list items

🤖 Generated with [Claude Code](https://claude.com/claude-code)