### PR TITLE
Reposition StrawHub as AI Workforce Registry with roles-first ordering

### DIFF
--- a/e2e/search.pw.test.ts
+++ b/e2e/search.pw.test.ts
@@ -4,7 +4,7 @@ test.describe("Search page", () => {
   test("shows prompt when query is too short", async ({ page }) => {
     await page.goto("/search");
     const input = page.locator(
-      'input[placeholder="Search skills and roles..."]',
+      'input[placeholder="Search roles, skills, and agents..."]',
     );
     await input.fill("a");
     await expect(
@@ -18,8 +18,8 @@ test.describe("Search page", () => {
     await expect(select).toBeVisible();
     await expect(select.locator("option")).toHaveText([
       "All",
-      "Skills",
       "Roles",
+      "Skills",
       "Agents",
     ]);
   });

--- a/e2e/smoke.pw.test.ts
+++ b/e2e/smoke.pw.test.ts
@@ -18,13 +18,13 @@ test.describe("Smoke tests", () => {
 
   test("upload page requires authentication", async ({ page }) => {
     await page.goto("/upload");
-    await expect(page.locator("text=Sign in with GitHub to publish skills, roles, and agents.")).toBeVisible();
+    await expect(page.locator("text=Sign in with GitHub to publish roles, skills, and agents.")).toBeVisible();
   });
 
   test("homepage renders hero content", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("h1")).toContainText("StrawHub");
-    await expect(page.locator("text=The role, skill, and agent registry for")).toBeVisible();
+    await expect(page.locator("text=The AI workforce registry for")).toBeVisible();
     await expect(page.locator("h2", { hasText: "Roles" })).toBeVisible();
     await expect(page.locator("h2", { hasText: "Skills" })).toBeVisible();
     await expect(page.locator("text=strawhub install role implementer")).toBeVisible();
@@ -33,7 +33,7 @@ test.describe("Smoke tests", () => {
   test("search page loads with input", async ({ page }) => {
     await page.goto("/search");
     await expect(page.locator("h1")).toContainText("Search");
-    await expect(page.locator('input[placeholder="Search skills and roles..."]')).toBeVisible();
+    await expect(page.locator('input[placeholder="Search roles, skills, and agents..."]')).toBeVisible();
     await expect(page.locator("text=Type at least 2 characters to search.")).toBeVisible();
   });
 
@@ -51,7 +51,7 @@ test.describe("Smoke tests", () => {
 
   test("dashboard requires authentication", async ({ page }) => {
     await page.goto("/dashboard");
-    await expect(page.locator("text=Sign in with GitHub to manage your published skills, roles, and agents.")).toBeVisible();
+    await expect(page.locator("text=Sign in with GitHub to manage your published roles, skills, and agents.")).toBeVisible();
   });
 
   test("settings requires authentication", async ({ page }) => {
@@ -61,7 +61,7 @@ test.describe("Smoke tests", () => {
 
   test("stars page requires authentication", async ({ page }) => {
     await page.goto("/stars");
-    await expect(page.locator("text=Sign in with GitHub to see skills, roles, and agents you've starred.")).toBeVisible();
+    await expect(page.locator("text=Sign in with GitHub to see roles, skills, and agents you've starred.")).toBeVisible();
   });
 
   test("users page requires authentication", async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -5,20 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>StrawHub</title>
-    <meta name="description" content="Discover, share, and install reusable roles and skills for your StrawPot agents." />
+    <meta name="description" content="Discover, install, and share AI workers for your StrawPot agents. Roles bundle skills, tools, and model config." />
     <link rel="canonical" href="https://strawhub.dev/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="StrawHub" />
-    <meta property="og:title" content="StrawHub - Role & Skill Registry for StrawPot" />
-    <meta property="og:description" content="Discover, share, and install reusable roles and skills for your StrawPot agents." />
+    <meta property="og:title" content="StrawHub - AI Workforce Registry for StrawPot" />
+    <meta property="og:description" content="Discover, install, and share AI workers for your StrawPot agents. Roles bundle skills, tools, and model config." />
     <meta property="og:url" content="https://strawhub.dev/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="StrawHub - Role & Skill Registry for StrawPot" />
-    <meta name="twitter:description" content="Discover, share, and install reusable roles and skills for your StrawPot agents." />
+    <meta name="twitter:title" content="StrawHub - AI Workforce Registry for StrawPot" />
+    <meta name="twitter:description" content="Discover, install, and share AI workers for your StrawPot agents. Roles bundle skills, tools, and model config." />
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/useSEO.test.ts
+++ b/src/lib/useSEO.test.ts
@@ -106,7 +106,7 @@ describe("resetSEO", () => {
     applySEO({ title: "T", url: "/skills/foo" });
     resetSEO();
     expect(getMeta("property", "og:title")).toBe(
-      `${BASE_TITLE} - Skill, Role & Agent Registry for StrawPot`,
+      `${BASE_TITLE} - AI Workforce Registry for StrawPot`,
     );
     expect(getMeta("property", "og:description")).toBe(DEFAULT_DESCRIPTION);
     expect(getMeta("property", "og:url")).toBe(`${BASE_URL}/`);
@@ -116,7 +116,7 @@ describe("resetSEO", () => {
     applySEO({ title: "T" });
     resetSEO();
     expect(getMeta("name", "twitter:title")).toBe(
-      `${BASE_TITLE} - Skill, Role & Agent Registry for StrawPot`,
+      `${BASE_TITLE} - AI Workforce Registry for StrawPot`,
     );
     expect(getMeta("name", "twitter:description")).toBe(DEFAULT_DESCRIPTION);
   });

--- a/src/lib/useSEO.ts
+++ b/src/lib/useSEO.ts
@@ -10,7 +10,7 @@ export interface SEOOptions {
 export const BASE_TITLE = "StrawHub";
 export const BASE_URL = "https://strawhub.dev";
 export const DEFAULT_DESCRIPTION =
-  "Discover, share, and install reusable skills, roles, and agents for your StrawPot agents.";
+  "Discover, install, and share AI workers for your StrawPot agents. Roles bundle skills, tools, and model config.";
 
 /** Set a <meta> tag by name or property attribute. */
 export function setMeta(attr: "name" | "property", key: string, value: string) {
@@ -68,10 +68,10 @@ export function applySEO({ title, description, url, noindex }: SEOOptions) {
 export function resetSEO() {
   document.title = BASE_TITLE;
   setMeta("name", "description", DEFAULT_DESCRIPTION);
-  setMeta("property", "og:title", `${BASE_TITLE} - Skill, Role & Agent Registry for StrawPot`);
+  setMeta("property", "og:title", `${BASE_TITLE} - AI Workforce Registry for StrawPot`);
   setMeta("property", "og:description", DEFAULT_DESCRIPTION);
   setMeta("property", "og:url", `${BASE_URL}/`);
-  setMeta("name", "twitter:title", `${BASE_TITLE} - Skill, Role & Agent Registry for StrawPot`);
+  setMeta("name", "twitter:title", `${BASE_TITLE} - AI Workforce Registry for StrawPot`);
   setMeta("name", "twitter:description", DEFAULT_DESCRIPTION);
   setCanonical(`${BASE_URL}/`);
   const robotsEl = document.querySelector<HTMLMetaElement>(

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -26,11 +26,11 @@ function RootLayout() {
           </Link>
 
           {/* Desktop nav links */}
-          <Link to="/skills" className="hidden md:block text-sm text-gray-400 hover:text-white">
-            Skills
-          </Link>
           <Link to="/roles" className="hidden md:block text-sm text-gray-400 hover:text-white">
             Roles
+          </Link>
+          <Link to="/skills" className="hidden md:block text-sm text-gray-400 hover:text-white">
+            Skills
           </Link>
           <Link to="/agents" className="hidden md:block text-sm text-gray-400 hover:text-white">
             Agents
@@ -79,11 +79,11 @@ function RootLayout() {
         {/* Mobile menu dropdown */}
         {mobileMenuOpen && (
           <div className="md:hidden border-t border-gray-800 px-4 py-3 space-y-1">
-            <Link to="/skills" onClick={() => setMobileMenuOpen(false)} className="block py-2 text-sm text-gray-400 hover:text-white">
-              Skills
-            </Link>
             <Link to="/roles" onClick={() => setMobileMenuOpen(false)} className="block py-2 text-sm text-gray-400 hover:text-white">
               Roles
+            </Link>
+            <Link to="/skills" onClick={() => setMobileMenuOpen(false)} className="block py-2 text-sm text-gray-400 hover:text-white">
+              Skills
             </Link>
             <Link to="/agents" onClick={() => setMobileMenuOpen(false)} className="block py-2 text-sm text-gray-400 hover:text-white">
               Agents
@@ -105,7 +105,7 @@ function RootLayout() {
       </main>
       <footer className="border-t border-gray-800 py-6 text-center text-sm text-gray-500">
         <p>
-          StrawHub &middot; A{" "}
+          StrawHub &middot; AI workforce registry &middot; A{" "}
           <a
             href="https://strawpot.com"
             className="underline decoration-gray-700 hover:decoration-gray-400 transition-colors"

--- a/src/routes/agents.index.tsx
+++ b/src/routes/agents.index.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 20;
 function AgentsPage() {
   useSEO({
     title: "Agents - StrawHub",
-    description: "Browse CLI wrapper agents for StrawPot that translate protocols into native AI tool interfaces.",
+    description: "Browse CLI runtimes for StrawPot that execute roles and translate protocols into native AI tool interfaces.",
     url: "/agents",
   });
 
@@ -73,7 +73,7 @@ function AgentsPage() {
       </div>
 
       <p className="text-gray-400">
-        CLI wrapper binaries that translate StrawPot's protocol into
+        CLI runtimes that execute roles. Translate StrawPot's protocol into
         native AI tool interfaces.
       </p>
 

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -29,7 +29,7 @@ function DashboardPage() {
         <h1 className="text-2xl md:text-3xl font-bold text-white">Dashboard</h1>
         <div className="rounded-lg border border-gray-800 p-5 md:p-8 text-center">
           <p className="text-gray-400 mb-4">
-            Sign in with GitHub to manage your published skills, roles, and agents.
+            Sign in with GitHub to manage your published roles, skills, and agents.
           </p>
           <button
             onClick={() => void signIn("github")}
@@ -83,7 +83,7 @@ function UserContent({ userId }: { userId: string; handle?: string }) {
           No content yet
         </p>
         <p className="text-sm text-gray-500 mb-6">
-          Publish your first skill, role, or agent to share it with the community.
+          Publish your first role, skill, or agent to share it with the community.
         </p>
         <Link
           to="/upload"
@@ -97,58 +97,6 @@ function UserContent({ userId }: { userId: string; handle?: string }) {
 
   return (
     <div className="space-y-8">
-      {/* Skills */}
-      {hasSkills && (
-        <section className="space-y-3">
-          <h2 className="text-xl font-semibold text-white">Skills</h2>
-          <div className="space-y-3">
-            {skills.map((s) => (
-              <div
-                key={s._id}
-                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
-              >
-                <div className="min-w-0 flex-1">
-                  <Link
-                    to="/skills/$slug"
-                    params={{ slug: s.slug }}
-                    className="text-base font-medium text-white hover:text-orange-400"
-                  >
-                    {s.displayName}
-                  </Link>
-                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
-                  {s.summary && (
-                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
-                      {s.summary}
-                    </p>
-                  )}
-                  <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-gray-500">
-                    <span>{s.stats.downloads} installs</span>
-                    <span>{s.stats.stars} stars</span>
-                    <span>{s.stats.versions} versions</span>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Link
-                    to="/upload"
-                    search={{ updateSlug: s.slug }}
-                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                  >
-                    New Version
-                  </Link>
-                  <Link
-                    to="/skills/$slug"
-                    params={{ slug: s.slug }}
-                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                  >
-                    View
-                  </Link>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
       {/* Roles */}
       {hasRoles && (
         <section className="space-y-3">
@@ -190,6 +138,58 @@ function UserContent({ userId }: { userId: string; handle?: string }) {
                   <Link
                     to="/roles/$slug"
                     params={{ slug: r.slug }}
+                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                  >
+                    View
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Skills */}
+      {hasSkills && (
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold text-white">Skills</h2>
+          <div className="space-y-3">
+            {skills.map((s) => (
+              <div
+                key={s._id}
+                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <Link
+                    to="/skills/$slug"
+                    params={{ slug: s.slug }}
+                    className="text-base font-medium text-white hover:text-orange-400"
+                  >
+                    {s.displayName}
+                  </Link>
+                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
+                  {s.summary && (
+                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
+                      {s.summary}
+                    </p>
+                  )}
+                  <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-gray-500">
+                    <span>{s.stats.downloads} installs</span>
+                    <span>{s.stats.stars} stars</span>
+                    <span>{s.stats.versions} versions</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Link
+                    to="/upload"
+                    search={{ updateSlug: s.slug }}
+                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                  >
+                    New Version
+                  </Link>
+                  <Link
+                    to="/skills/$slug"
+                    params={{ slug: s.slug }}
                     className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
                   >
                     View
@@ -274,55 +274,6 @@ function StarredContent() {
     <div className="space-y-8">
       <h2 className="text-xl font-semibold text-white">Starred</h2>
 
-      {hasSkills && (
-        <section className="space-y-3">
-          <h3 className="text-sm font-medium text-gray-400">Skills</h3>
-          <div className="space-y-3">
-            {starred.skills.map((s) => (
-              <div
-                key={s._id}
-                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
-              >
-                <div className="min-w-0 flex-1">
-                  <Link
-                    to="/skills/$slug"
-                    params={{ slug: s.slug }}
-                    className="text-base font-medium text-white hover:text-orange-400"
-                  >
-                    {s.displayName}
-                  </Link>
-                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
-                  {s.summary && (
-                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
-                      {s.summary}
-                    </p>
-                  )}
-                </div>
-                <button
-                  onClick={() => toggleStar({ targetId: s._id, targetKind: "skill" })}
-                  className="inline-flex items-center gap-1 text-yellow-400 hover:text-gray-400 transition-colors text-xs shrink-0"
-                >
-                  <svg
-                    className="h-3.5 w-3.5"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
-                    />
-                  </svg>
-                  Unstar
-                </button>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
       {hasRoles && (
         <section className="space-y-3">
           <h3 className="text-sm font-medium text-gray-400">Roles</h3>
@@ -349,6 +300,55 @@ function StarredContent() {
                 </div>
                 <button
                   onClick={() => toggleStar({ targetId: r._id, targetKind: "role" })}
+                  className="inline-flex items-center gap-1 text-yellow-400 hover:text-gray-400 transition-colors text-xs shrink-0"
+                >
+                  <svg
+                    className="h-3.5 w-3.5"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                  Unstar
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {hasSkills && (
+        <section className="space-y-3">
+          <h3 className="text-sm font-medium text-gray-400">Skills</h3>
+          <div className="space-y-3">
+            {starred.skills.map((s) => (
+              <div
+                key={s._id}
+                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <Link
+                    to="/skills/$slug"
+                    params={{ slug: s.slug }}
+                    className="text-base font-medium text-white hover:text-orange-400"
+                  >
+                    {s.displayName}
+                  </Link>
+                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
+                  {s.summary && (
+                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
+                      {s.summary}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => toggleStar({ targetId: s._id, targetKind: "skill" })}
                   className="inline-flex items-center gap-1 text-yellow-400 hover:text-gray-400 transition-colors text-xs shrink-0"
                 >
                   <svg

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   useSEO({
-    title: "StrawHub - Role, Skill & Agent Registry for StrawPot",
+    title: "StrawHub - AI Workforce Registry for StrawPot",
     url: "/",
   });
 
@@ -16,47 +16,47 @@ function HomePage() {
       <section className="text-center py-8 md:py-16">
         <h1 className="text-3xl md:text-5xl font-bold text-white mb-4">StrawHub</h1>
         <p className="text-lg md:text-xl text-gray-400 mb-8">
-          The role, skill, and agent registry for{" "}
+          The AI workforce registry for{" "}
           <span className="text-orange-400">StrawPot</span>
         </p>
         <p className="text-gray-500 max-w-2xl mx-auto">
-          Discover, share, and install reusable roles, skills, and agents for your
-          StrawPot agents. Roles define agent behavior with dependent skills
-          that are resolved recursively on install.
+          Discover, install, and share AI workers for your StrawPot agents.
+          Roles define agent behavior and bundle all required skills
+          automatically on install.
         </p>
       </section>
 
       <section className="grid grid-cols-1 md:grid-cols-3 gap-8">
         <Link
           to="/roles"
-          className="block rounded-lg border border-gray-800 p-5 md:p-8 hover:border-orange-400/50 transition-colors"
+          className="block rounded-lg border border-orange-400/30 bg-orange-400/5 p-5 md:p-8 hover:border-orange-400/50 transition-colors"
         >
           <h2 className="text-2xl font-bold text-white mb-2">Roles</h2>
           <p className="text-gray-400">
-            Agent behavior definitions with default tools, model config, and
-            skill dependencies. Install a role and all its skills come with it.
+            AI workers that bundle skills, tools, and model config. Install a
+            role and get a ready-to-work agent with all required capabilities.
           </p>
         </Link>
 
         <Link
           to="/skills"
-          className="block rounded-lg border border-gray-800 p-5 md:p-8 hover:border-orange-400/50 transition-colors"
+          className="block rounded-lg border border-gray-800 p-5 md:p-8 hover:border-gray-600 transition-colors"
         >
           <h2 className="text-2xl font-bold text-white mb-2">Skills</h2>
           <p className="text-gray-400">
-            Markdown instruction modules that agents load into context. Skills
-            can depend on other skills for recursive resolution.
+            Capabilities that roles load into context. Skills are installed
+            automatically as role dependencies.
           </p>
         </Link>
 
         <Link
           to="/agents"
-          className="block rounded-lg border border-gray-800 p-5 md:p-8 hover:border-orange-400/50 transition-colors"
+          className="block rounded-lg border border-gray-800 p-5 md:p-8 hover:border-gray-600 transition-colors"
         >
           <h2 className="text-2xl font-bold text-white mb-2">Agents</h2>
           <p className="text-gray-400">
-            CLI wrapper binaries that translate StrawPot's protocol into
-            native AI tool interfaces.
+            CLI runtimes that execute roles. Agents translate StrawPot's
+            protocol into native AI tool interfaces.
           </p>
         </Link>
       </section>
@@ -69,8 +69,29 @@ function HomePage() {
           strawhub install role implementer
         </code>
         <p className="text-gray-500 text-sm mt-2">
-          Installs the role + all dependent skills recursively
+          Installs the role + all required skills automatically
         </p>
+      </section>
+
+      <section className="text-center py-8 border-t border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-300 mb-2">
+          Share Your Roles
+        </h3>
+        <p className="text-gray-500 max-w-lg mx-auto mb-4">
+          Built an AI worker? Share it with the community.
+        </p>
+        <code className="rounded bg-gray-900 px-6 py-3 text-sm text-orange-400 inline-block max-w-full overflow-x-auto mb-4">
+          strawpot publish role analyst
+        </code>
+        <div>
+          <Link
+            to="/upload"
+            search={{ kind: "role" }}
+            className="inline-block rounded bg-orange-500 px-6 py-2 text-sm font-medium text-white hover:bg-orange-600"
+          >
+            Publish a Role
+          </Link>
+        </div>
       </section>
     </div>
   );

--- a/src/routes/roles.index.tsx
+++ b/src/routes/roles.index.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 20;
 function RolesPage() {
   useSEO({
     title: "Roles - StrawHub",
-    description: "Browse agent role definitions for StrawPot with recursive skill dependencies.",
+    description: "Browse AI workers for StrawPot. Roles bundle skills, tools, and model config with automatic dependency resolution.",
     url: "/roles",
   });
 
@@ -73,8 +73,8 @@ function RolesPage() {
       </div>
 
       <p className="text-gray-400">
-        Agent behavior definitions with dependent skills that are resolved
-        recursively on install.
+        AI workers that bundle skills, tools, and model config. Install a role
+        and all required skills come with it.
       </p>
 
       <input

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 20;
 function SearchPage() {
   useSEO({
     title: "Search - StrawHub",
-    description: "Search for skills, roles, and agents on StrawHub.",
+    description: "Search for roles, skills, and agents on StrawHub.",
     url: "/search",
   });
 
@@ -61,7 +61,7 @@ function SearchPage() {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search skills and roles..."
+          placeholder="Search roles, skills, and agents..."
           className="flex-1 rounded border border-gray-700 bg-gray-900 px-4 py-2 text-white placeholder-gray-500 focus:border-orange-400 focus:outline-none"
         />
         <select
@@ -70,8 +70,8 @@ function SearchPage() {
           className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-gray-300"
         >
           <option value="all">All</option>
-          <option value="skill">Skills</option>
           <option value="role">Roles</option>
+          <option value="skill">Skills</option>
           <option value="agent">Agents</option>
         </select>
       </div>

--- a/src/routes/skills.index.tsx
+++ b/src/routes/skills.index.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 20;
 function SkillsPage() {
   useSEO({
     title: "Skills - StrawHub",
-    description: "Browse reusable skill modules for StrawPot agents.",
+    description: "Browse reusable skill capabilities for StrawPot roles. Skills are installed automatically as role dependencies.",
     url: "/skills",
   });
 
@@ -72,7 +72,8 @@ function SkillsPage() {
       </div>
 
       <p className="text-gray-400">
-        Markdown instruction modules that agents load into context.
+        Capabilities that roles load into context. Installed automatically as
+        role dependencies.
       </p>
 
       <input

--- a/src/routes/stars.tsx
+++ b/src/routes/stars.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/stars")({
 function StarsPage() {
   useSEO({
     title: "Stars - StrawHub",
-    description: "Skills, roles, and agents you've starred on StrawHub.",
+    description: "Roles, skills, and agents you've starred on StrawHub.",
     url: "/stars",
     noindex: true,
   });
@@ -29,7 +29,7 @@ function StarsPage() {
         <h1 className="text-2xl md:text-3xl font-bold text-white">Stars</h1>
         <div className="rounded-lg border border-gray-800 p-5 md:p-8 text-center">
           <p className="text-gray-400 mb-4">
-            Sign in with GitHub to see skills, roles, and agents you've starred.
+            Sign in with GitHub to see roles, skills, and agents you've starred.
           </p>
           <button
             onClick={() => void signIn("github")}
@@ -46,7 +46,7 @@ function StarsPage() {
     <div className="space-y-6">
       <h1 className="text-2xl md:text-3xl font-bold text-white">Stars</h1>
       <p className="text-gray-400">
-        Skills, roles, and agents you've starred.
+        Roles, skills, and agents you've starred.
       </p>
       <StarredList />
     </div>
@@ -72,20 +72,20 @@ function StarredList() {
           No starred items yet
         </p>
         <p className="text-sm text-gray-500 mb-6">
-          Star skills, roles, and agents to keep track of them here.
+          Star roles, skills, and agents to keep track of them here.
         </p>
         <div className="flex items-center justify-center gap-3">
-          <Link
-            to="/skills"
-            className="rounded border border-gray-700 px-4 py-2 text-sm text-gray-300 hover:bg-gray-800"
-          >
-            Browse Skills
-          </Link>
           <Link
             to="/roles"
             className="rounded border border-gray-700 px-4 py-2 text-sm text-gray-300 hover:bg-gray-800"
           >
             Browse Roles
+          </Link>
+          <Link
+            to="/skills"
+            className="rounded border border-gray-700 px-4 py-2 text-sm text-gray-300 hover:bg-gray-800"
+          >
+            Browse Skills
           </Link>
           <Link
             to="/agents"
@@ -100,63 +100,6 @@ function StarredList() {
 
   return (
     <div className="space-y-8">
-      {hasSkills && (
-        <section className="space-y-3">
-          <h2 className="text-xl font-semibold text-white">
-            Skills
-            <span className="ml-2 font-normal text-gray-500">({starred.skills.length})</span>
-          </h2>
-          <div className="space-y-3">
-            {starred.skills.map((s) => (
-              <div
-                key={s._id}
-                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
-              >
-                <div className="min-w-0 flex-1">
-                  <Link
-                    to="/skills/$slug"
-                    params={{ slug: s.slug }}
-                    className="text-base font-medium text-white hover:text-orange-400"
-                  >
-                    {s.displayName}
-                  </Link>
-                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
-                  {s.summary && (
-                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
-                      {s.summary}
-                    </p>
-                  )}
-                  <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-gray-500">
-                    <span>{s.stats.downloads} installs</span>
-                    <span>{s.stats.stars} stars</span>
-                    <span>{s.stats.versions} versions</span>
-                  </div>
-                </div>
-                <button
-                  onClick={() => toggleStar({ targetId: s._id, targetKind: "skill" })}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-1 text-sm font-medium text-yellow-400 hover:bg-yellow-500/20 transition-colors shrink-0"
-                >
-                  <svg
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
-                    />
-                  </svg>
-                  Unstar
-                </button>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
       {hasRoles && (
         <section className="space-y-3">
           <h2 className="text-xl font-semibold text-white">
@@ -191,6 +134,63 @@ function StarredList() {
                 </div>
                 <button
                   onClick={() => toggleStar({ targetId: r._id, targetKind: "role" })}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-1 text-sm font-medium text-yellow-400 hover:bg-yellow-500/20 transition-colors shrink-0"
+                >
+                  <svg
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                  Unstar
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {hasSkills && (
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold text-white">
+            Skills
+            <span className="ml-2 font-normal text-gray-500">({starred.skills.length})</span>
+          </h2>
+          <div className="space-y-3">
+            {starred.skills.map((s) => (
+              <div
+                key={s._id}
+                className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-gray-800 p-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <Link
+                    to="/skills/$slug"
+                    params={{ slug: s.slug }}
+                    className="text-base font-medium text-white hover:text-orange-400"
+                  >
+                    {s.displayName}
+                  </Link>
+                  <p className="text-xs text-gray-500 font-mono">/{s.slug}</p>
+                  {s.summary && (
+                    <p className="mt-1 text-sm text-gray-400 line-clamp-2">
+                      {s.summary}
+                    </p>
+                  )}
+                  <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-gray-500">
+                    <span>{s.stats.downloads} installs</span>
+                    <span>{s.stats.stars} stars</span>
+                    <span>{s.stats.versions} versions</span>
+                  </div>
+                </div>
+                <button
+                  onClick={() => toggleStar({ targetId: s._id, targetKind: "skill" })}
                   className="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-1 text-sm font-medium text-yellow-400 hover:bg-yellow-500/20 transition-colors shrink-0"
                 >
                   <svg

--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -74,7 +74,7 @@ interface UploadFile {
 function UploadPage() {
   useSEO({
     title: "Publish - StrawHub",
-    description: "Publish or update a skill, role, or agent on StrawHub.",
+    description: "Publish or update a role, skill, or agent on StrawHub.",
     url: "/upload",
   });
 
@@ -83,7 +83,7 @@ function UploadPage() {
   const navigate = useNavigate();
   const { mode, updateSlug, kind: initialKind } = Route.useSearch();
 
-  const [kind, setKind] = useState<"skill" | "role" | "agent">(initialKind ?? "skill");
+  const [kind, setKind] = useState<"skill" | "role" | "agent">(initialKind ?? "role");
   const [slug, setSlug] = useState(updateSlug ?? "");
   const [displayName, setDisplayName] = useState(
     updateSlug
@@ -525,7 +525,7 @@ function UploadPage() {
         <h1 className="text-3xl font-bold text-white">Publish</h1>
         <div className="rounded-lg border border-gray-800 p-8 text-center">
           <p className="text-gray-400 mb-4">
-            Sign in with GitHub to publish skills, roles, and agents.
+            Sign in with GitHub to publish roles, skills, and agents.
           </p>
           <button
             onClick={() => void signIn("github")}
@@ -546,16 +546,6 @@ function UploadPage() {
         {/* Kind Toggle */}
         <div className="flex gap-4">
           <button
-            onClick={() => { setKind("skill"); setFiles([]); setError(null); }}
-            className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
-              kind === "skill"
-                ? "bg-orange-500 text-white"
-                : "bg-gray-800 text-gray-400 hover:text-white"
-            }`}
-          >
-            Skill
-          </button>
-          <button
             onClick={() => { setKind("role"); setFiles([]); setError(null); }}
             className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
               kind === "role"
@@ -564,6 +554,16 @@ function UploadPage() {
             }`}
           >
             Role
+          </button>
+          <button
+            onClick={() => { setKind("skill"); setFiles([]); setError(null); }}
+            className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
+              kind === "skill"
+                ? "bg-orange-500 text-white"
+                : "bg-gray-800 text-gray-400 hover:text-white"
+            }`}
+          >
+            Skill
           </button>
           <button
             onClick={() => { setKind("agent"); setFiles([]); setError(null); }}
@@ -597,7 +597,7 @@ function UploadPage() {
                   type="text"
                   value={githubUrl}
                   onChange={(e) => setGithubUrl(e.target.value)}
-                  placeholder="https://github.com/user/repo/tree/main/skills/my-skill"
+                  placeholder={kind === "role" ? "https://github.com/user/repo/tree/main/roles/my-role" : kind === "agent" ? "https://github.com/user/repo/tree/main/agents/my-agent" : "https://github.com/user/repo/tree/main/skills/my-skill"}
                   className="flex-1 rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-orange-400 focus:outline-none"
                 />
                 <button


### PR DESCRIPTION
## Summary
- Repositions StrawHub as an **AI Workforce Registry** where roles are the primary artifact, with updated hero, feature grid, install section, and a new "Share Your Roles" CTA on the homepage
- Reorders all user-facing text, navigation, search filters, publish page defaults, dashboard, and stars page to put **Roles before Skills** consistently
- Updates SEO meta tags, OG/Twitter titles, static HTML, and descriptions site-wide to reflect the new positioning
- Fixes E2E smoke/search tests and unit tests to match updated copy and ordering

## Test plan
- [x] All 184 unit tests pass (`npm test`)
- [ ] Run E2E tests against dev server to verify smoke and search tests pass
- [ ] Visually confirm homepage shows roles-first grid with orange accent border
- [ ] Verify nav order is Roles, Skills, Agents across desktop and mobile
- [ ] Check publish page defaults to Role with dynamic GitHub import placeholder
- [ ] Confirm search dropdown shows All, Roles, Skills, Agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)