### PR TITLE
Add VirusTotal scanning for agent versions

### DIFF
--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter } from "./lib/frontmatter";
 import { parseVersion, compareVersions } from "./lib/versionSpec";
@@ -260,6 +261,14 @@ export const publishInternal = internalMutation({
       updatedAt: now,
     });
 
+    // Trigger VirusTotal scan
+    await ctx.scheduler.runAfter(0, internal.virusTotalScanActions.submitAgentScan, {
+      versionId,
+      agentId: agent._id,
+      zipStorageId: args.zipStorageId,
+      zipFileName: `${args.slug}-v${version}.zip`,
+    });
+
     return { agentId: agent._id, versionId };
   },
 });
@@ -375,6 +384,14 @@ export const publish = mutation({
       tags: currentTags,
       stats: { ...agent.stats, versions: agent.stats.versions + 1 },
       updatedAt: now,
+    });
+
+    // Trigger VirusTotal scan
+    await ctx.scheduler.runAfter(0, internal.virusTotalScanActions.submitAgentScan, {
+      versionId,
+      agentId: agent._id,
+      zipStorageId: args.zipStorageId,
+      zipFileName: `${args.slug}-v${version}.zip`,
     });
 
     return { agentId: agent._id, versionId };

--- a/convex/virusTotalScan.ts
+++ b/convex/virusTotalScan.ts
@@ -42,11 +42,41 @@ export const getVersionFiles = internalQuery({
   },
 });
 
+/** Return the files array for an agent version (used by scan actions). */
+export const getAgentVersionFiles = internalQuery({
+  args: { versionId: v.id("agentVersions") },
+  handler: async (ctx, args) => {
+    const version = await ctx.db.get(args.versionId);
+    if (!version) return null;
+    return (version.files ?? []) as Array<{
+      path: string;
+      size: number;
+      storageId: string;
+      sha256: string;
+      contentType?: string;
+    }>;
+  },
+});
+
 // ─── Internal Mutations ──────────────────────────────────────────────────────
 
 export const setScanStatus = internalMutation({
   args: {
     versionId: v.id("skillVersions"),
+    scanStatus: scanStatusLiterals,
+    scanResult: scanResultValidator,
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.versionId, {
+      scanStatus: args.scanStatus,
+      scanResult: args.scanResult,
+    });
+  },
+});
+
+export const setAgentScanStatus = internalMutation({
+  args: {
+    versionId: v.id("agentVersions"),
     scanStatus: scanStatusLiterals,
     scanResult: scanResultValidator,
   },
@@ -82,10 +112,34 @@ export const flagSkill = internalMutation({
   },
 });
 
+export const flagAgent = internalMutation({
+  args: {
+    agentId: v.id("agents"),
+    versionId: v.id("agentVersions"),
+    scanResult: v.object({
+      analysisId: v.optional(v.string()),
+      positives: v.optional(v.number()),
+      total: v.optional(v.number()),
+      scanDate: v.optional(v.number()),
+      permalink: v.optional(v.string()),
+      errorMessage: v.optional(v.string()),
+    }),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.versionId, {
+      scanStatus: "flagged" as const,
+      scanResult: args.scanResult,
+    });
+    await ctx.db.patch(args.agentId, {
+      moderationStatus: "hidden" as const,
+    });
+  },
+});
+
 // ─── Moderator Scan Queue ────────────────────────────────────────────────────
 
 /**
- * List skill versions that need scanning (rate_limited or error).
+ * List skill and agent versions that need scanning (rate_limited or error).
  * Returns items sorted by priority: high = latest version, low = superseded.
  * Admin/moderator only.
  */
@@ -100,22 +154,22 @@ export const listPendingScans = query({
       throw new Error("Not authorized");
     }
 
-    // Collect rate_limited and error versions
-    const rateLimited = await ctx.db
+    // Collect rate_limited and error skill versions
+    const skillRateLimited = await ctx.db
       .query("skillVersions")
       .filter((q) => q.eq(q.field("scanStatus"), "rate_limited"))
       .collect();
 
-    const errored = await ctx.db
+    const skillErrored = await ctx.db
       .query("skillVersions")
       .filter((q) => q.eq(q.field("scanStatus"), "error"))
       .collect();
 
-    const versions = [...rateLimited, ...errored];
+    const skillVersions = [...skillRateLimited, ...skillErrored];
 
     // Enrich with skill info and priority
-    const items = await Promise.all(
-      versions
+    const skillItems = await Promise.all(
+      skillVersions
         .filter((ver) => !ver.softDeletedAt)
         .map(async (ver) => {
           const skill = await ctx.db.get(ver.skillId);
@@ -126,7 +180,8 @@ export const listPendingScans = query({
 
           return {
             _id: ver._id,
-            skillId: ver.skillId,
+            kind: "skill" as const,
+            parentId: ver.skillId,
             slug: skill.slug,
             displayName: skill.displayName,
             version: ver.version,
@@ -138,6 +193,47 @@ export const listPendingScans = query({
           };
         }),
     );
+
+    // Collect rate_limited and error agent versions
+    const agentRateLimited = await ctx.db
+      .query("agentVersions")
+      .filter((q) => q.eq(q.field("scanStatus"), "rate_limited"))
+      .collect();
+
+    const agentErrored = await ctx.db
+      .query("agentVersions")
+      .filter((q) => q.eq(q.field("scanStatus"), "error"))
+      .collect();
+
+    const agentVersions = [...agentRateLimited, ...agentErrored];
+
+    const agentItems = await Promise.all(
+      agentVersions
+        .filter((ver) => !ver.softDeletedAt)
+        .map(async (ver) => {
+          const agent = await ctx.db.get(ver.agentId);
+          if (!agent || agent.softDeletedAt) return null;
+
+          const isLatest = agent.latestVersionId === ver._id;
+          const owner = await ctx.db.get(agent.ownerUserId);
+
+          return {
+            _id: ver._id,
+            kind: "agent" as const,
+            parentId: ver.agentId,
+            slug: agent.slug,
+            displayName: agent.displayName,
+            version: ver.version,
+            scanStatus: ver.scanStatus as string,
+            scanResult: ver.scanResult,
+            priority: isLatest ? ("high" as const) : ("low" as const),
+            owner: owner ? { handle: owner.handle, image: owner.image } : null,
+            createdAt: ver.createdAt,
+          };
+        }),
+    );
+
+    const items = [...skillItems, ...agentItems];
 
     // Filter nulls, sort: high priority first, then by creation date desc
     return items
@@ -185,6 +281,45 @@ export const retriggerScan = mutation({
       skillId: version.skillId,
       zipStorageId: version.zipStorageId,
       zipFileName: `${skill.slug}-v${version.version}.zip`,
+    });
+  },
+});
+
+/**
+ * Retrigger a VirusTotal scan for an agent version.
+ * Admin/moderator only. Only allowed for rate_limited or error versions.
+ */
+export const retriggerAgentScan = mutation({
+  args: { versionId: v.id("agentVersions") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const user = await ctx.db.get(userId);
+    if (user?.role !== "admin" && user?.role !== "moderator") {
+      throw new Error("Not authorized");
+    }
+
+    const version = await ctx.db.get(args.versionId);
+    if (!version) throw new Error("Version not found");
+
+    if (version.scanStatus !== "rate_limited" && version.scanStatus !== "error") {
+      throw new Error("Can only retrigger scans for rate_limited or errored versions");
+    }
+
+    const agent = await ctx.db.get(version.agentId);
+    if (!agent) throw new Error("Agent not found");
+
+    await ctx.db.patch(args.versionId, {
+      scanStatus: "pending",
+      scanResult: undefined,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.virusTotalScanActions.submitAgentScan, {
+      versionId: args.versionId,
+      agentId: version.agentId,
+      zipStorageId: version.zipStorageId,
+      zipFileName: `${agent.slug}-v${version.version}.zip`,
     });
   },
 });

--- a/convex/virusTotalScanActions.ts
+++ b/convex/virusTotalScanActions.ts
@@ -135,6 +135,96 @@ export const submitScan = internalAction({
 });
 
 /**
+ * Submit an agent version's zip archive to VirusTotal for scanning.
+ * Skips the scan when every file is detected as text.
+ * Marks as rate_limited if VT quota is exhausted.
+ */
+export const submitAgentScan = internalAction({
+  args: {
+    versionId: v.id("agentVersions"),
+    agentId: v.id("agents"),
+    zipStorageId: v.optional(v.id("_storage")),
+    zipFileName: v.string(),
+  },
+  handler: async (ctx, args) => {
+    if (!args.zipStorageId) {
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "error",
+        scanResult: { errorMessage: "No zip archive available for scanning" },
+      });
+      return;
+    }
+
+    // ── Text-file detection: skip scan if all files are text ──
+    const files = await ctx.runQuery(internal.virusTotalScan.getAgentVersionFiles, {
+      versionId: args.versionId,
+    });
+
+    if (files && files.length > 0 && await areAllFilesText(ctx, files)) {
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "skipped",
+        scanResult: {
+          errorMessage: "All files are text-based; VirusTotal scan skipped",
+        },
+      });
+      return;
+    }
+
+    if (!process.env.VIRUSTOTAL_API_KEY) {
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "rate_limited",
+        scanResult: { errorMessage: "VIRUSTOTAL_API_KEY not configured" },
+      });
+      return;
+    }
+
+    const zipBlob = await ctx.storage.get(args.zipStorageId);
+    if (!zipBlob) {
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "error",
+        scanResult: { errorMessage: "Zip file not found in storage" },
+      });
+      return;
+    }
+
+    try {
+      const { analysisId } = await submitFileToVT(zipBlob, args.zipFileName);
+
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "scanning",
+        scanResult: { analysisId },
+      });
+
+      await ctx.scheduler.runAfter(60_000, internal.virusTotalScanActions.pollAgentResult, {
+        versionId: args.versionId,
+        agentId: args.agentId,
+        analysisId,
+        attemptNumber: 0,
+      });
+    } catch (error: any) {
+      if (error instanceof VTRateLimitError) {
+        await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+          versionId: args.versionId,
+          scanStatus: "rate_limited",
+          scanResult: { errorMessage: "VirusTotal API rate limit exceeded" },
+        });
+      } else {
+        await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+          versionId: args.versionId,
+          scanStatus: "error",
+          scanResult: { errorMessage: error.message ?? "Unknown submission error" },
+        });
+      }
+    }
+  },
+});
+
+/**
  * Poll VirusTotal for analysis results. Reschedules itself if not yet done.
  */
 export const pollResult = internalAction({
@@ -207,6 +297,89 @@ export const pollResult = internalAction({
         );
       } else {
         await ctx.runMutation(internal.virusTotalScan.setScanStatus, {
+          versionId: args.versionId,
+          scanStatus: "error",
+          scanResult: {
+            analysisId: args.analysisId,
+            errorMessage: error.message ?? "Poll error after max retries",
+          },
+        });
+      }
+    }
+  },
+});
+
+/**
+ * Poll VirusTotal for agent version analysis results.
+ */
+export const pollAgentResult = internalAction({
+  args: {
+    versionId: v.id("agentVersions"),
+    agentId: v.id("agents"),
+    analysisId: v.string(),
+    attemptNumber: v.number(),
+  },
+  handler: async (ctx, args) => {
+    if (args.attemptNumber >= MAX_POLL_ATTEMPTS) {
+      await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+        versionId: args.versionId,
+        scanStatus: "error",
+        scanResult: {
+          analysisId: args.analysisId,
+          errorMessage: "Scan timed out after maximum poll attempts",
+        },
+      });
+      return;
+    }
+
+    try {
+      const result = await getVTAnalysis(args.analysisId);
+
+      if (result.status === "queued") {
+        const delay = Math.min(60_000 * 1.5 ** args.attemptNumber, 300_000);
+        await ctx.scheduler.runAfter(delay, internal.virusTotalScanActions.pollAgentResult, {
+          ...args,
+          attemptNumber: args.attemptNumber + 1,
+        });
+        return;
+      }
+
+      const positives =
+        (result.stats?.malicious ?? 0) + (result.stats?.suspicious ?? 0);
+      const total = result.stats
+        ? Object.values(result.stats).reduce((a, b) => a + b, 0)
+        : 0;
+
+      const scanResult = {
+        analysisId: args.analysisId,
+        positives,
+        total,
+        scanDate: Date.now(),
+        permalink: result.permalink,
+      };
+
+      if (positives > 0) {
+        await ctx.runMutation(internal.virusTotalScan.flagAgent, {
+          agentId: args.agentId,
+          versionId: args.versionId,
+          scanResult,
+        });
+      } else {
+        await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
+          versionId: args.versionId,
+          scanStatus: "clean",
+          scanResult,
+        });
+      }
+    } catch (error: any) {
+      if (args.attemptNumber < MAX_POLL_ATTEMPTS - 1) {
+        await ctx.scheduler.runAfter(
+          60_000,
+          internal.virusTotalScanActions.pollAgentResult,
+          { ...args, attemptNumber: args.attemptNumber + 1 },
+        );
+      } else {
+        await ctx.runMutation(internal.virusTotalScan.setAgentScanStatus, {
           versionId: args.versionId,
           scanStatus: "error",
           scanResult: {

--- a/src/routes/scan-queue.tsx
+++ b/src/routes/scan-queue.tsx
@@ -18,6 +18,7 @@ function ScanQueuePage() {
   const currentUser = useQuery(api.users.me);
   const items = useQuery(api.virusTotalScan.listPendingScans);
   const retriggerScan = useMutation(api.virusTotalScan.retriggerScan);
+  const retriggerAgentScan = useMutation(api.virusTotalScan.retriggerAgentScan);
 
   if (isLoading) {
     return <p className="text-gray-400">Loading...</p>;
@@ -54,7 +55,7 @@ function ScanQueuePage() {
       <div>
         <h1 className="text-2xl md:text-3xl font-bold text-white">Scan Queue</h1>
         <p className="text-sm text-gray-500 mt-1">
-          Skill versions that need VirusTotal scanning. High priority = latest version.
+          Skill and agent versions that need VirusTotal scanning. High priority = latest version.
         </p>
       </div>
 
@@ -69,7 +70,11 @@ function ScanQueuePage() {
               key={item._id}
               item={item}
               onRetrigger={async () => {
-                await retriggerScan({ versionId: item._id });
+                if (item.kind === "agent") {
+                  await retriggerAgentScan({ versionId: item._id as any });
+                } else {
+                  await retriggerScan({ versionId: item._id as any });
+                }
               }}
             />
           ))}
@@ -85,6 +90,7 @@ function ScanQueueCard({
 }: {
   item: {
     _id: any;
+    kind: "skill" | "agent";
     slug: string;
     displayName: string;
     version: string;
@@ -121,8 +127,11 @@ function ScanQueueCard({
             >
               {item.priority}
             </span>
+            <span className="rounded px-1.5 py-0.5 text-[10px] font-medium uppercase bg-gray-700/50 text-gray-400">
+              {item.kind}
+            </span>
             <Link
-              to="/skills/$slug"
+              to={item.kind === "agent" ? "/agents/$slug" : "/skills/$slug"}
               params={{ slug: item.slug }}
               className="text-sm font-medium text-orange-400 hover:text-orange-300 truncate"
             >


### PR DESCRIPTION
## Summary
- Trigger VirusTotal scanning on agent publish (both `publish` and `publishInternal` mutations), with the same text-file skip optimization used for skills
- Add agent-specific scan actions (`submitAgentScan`, `pollAgentResult`), mutations (`setAgentScanStatus`, `flagAgent`), and queries (`getAgentVersionFiles`)
- Update the moderator scan queue to show both skill and agent pending scans, with kind badge and correct detail page links
- Add `retriggerAgentScan` mutation for moderators to retry failed agent scans

## Test plan
- [ ] Publish an agent with only text files (e.g., AGENT.md) → verify scan status is "skipped"
- [ ] Publish an agent with binary files → verify scan is submitted to VirusTotal
- [ ] Check scan queue page shows agent items with "agent" badge and correct link
- [ ] Retry a failed agent scan from the scan queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)