### PR TITLE
Add example workers and role bundling diagram to homepage

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -60,6 +60,47 @@ function HomePage() {
         </Link>
       </section>
 
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-8 py-8">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-300 mb-4">
+            Example Workers
+          </h3>
+          <div className="space-y-3">
+            {[
+              ["implementer", "Write code to implement features and fix bugs"],
+              ["reviewer", "Review pull requests and suggest improvements"],
+              ["analyst", "Research information and produce structured reports"],
+              ["support-agent", "Triage issues and respond to user questions"],
+              ["product-manager", "Define requirements and prioritize work"],
+            ].map(([name, desc]) => (
+              <div key={name} className="flex gap-3 items-baseline">
+                <code className="text-orange-400 text-sm shrink-0">{name}</code>
+                <span className="text-gray-500 text-sm">{desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-gray-300 mb-4">
+            What a Role Bundles
+          </h3>
+          <pre className="text-sm text-gray-400 leading-relaxed"><code>{`role: analyst
+ ├─ skills
+ │   ├─ web-search
+ │   ├─ summarize-documents
+ │   ├─ extract-data
+ │   └─ report-writing
+ ├─ tools
+ │   └─ browser, jq
+ └─ model config
+     └─ claude-sonnet-4-5`}</code></pre>
+          <p className="text-gray-500 text-sm mt-3">
+            One install resolves everything.
+          </p>
+        </div>
+      </section>
+
       <section className="text-center py-8">
         <h3 className="text-lg font-semibold text-gray-300 mb-4">
           Get Started


### PR DESCRIPTION
## Summary
- Adds **Example Workers** section showing five role names with one-line descriptions (implementer, reviewer, analyst, support-agent, product-manager)
- Adds **What a Role Bundles** section with an ASCII tree diagram showing skills, tools, and model config inside a role
- Both sections appear in a side-by-side grid between the Roles/Skills/Agents cards and the "Get Started" install command

## Test plan
- [ ] Verify homepage renders the two new sections correctly on desktop (side-by-side) and mobile (stacked)
- [ ] Run `npm run typecheck` — passes
- [ ] Run `npm run test:e2e` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)