### PR TITLE
Add text file validation for SKILL.md and AGENT.md

### DIFF
--- a/convex/httpApiV1/agentsV1.ts
+++ b/convex/httpApiV1/agentsV1.ts
@@ -1,7 +1,7 @@
 import { httpAction } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import { jsonResponse, errorResponse, getSearchParams, resolveTokenToUser, checkHttpRateLimit } from "./shared";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles, AGENT_MAX_FILE_SIZE } from "../lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles, assertFileIsText, AGENT_MAX_FILE_SIZE } from "../lib/publishValidation";
 import { parseFrontmatter, extractName } from "../lib/frontmatter";
 import { createZipBlob } from "../lib/zip";
 
@@ -69,7 +69,6 @@ export async function handleGetAgentFile(ctx: any, request: Request): Promise<Re
   const blob = await ctx.storage.get(file.storageId);
   if (!blob) return errorResponse("File content unavailable", 500);
 
-  // Agents can contain binary files — serve with appropriate content type
   const buffer = await blob.arrayBuffer();
   return new Response(buffer, {
     headers: {
@@ -140,14 +139,21 @@ export const publishAgent = httpAction(async (ctx, request) => {
         const buffer = await file.arrayBuffer();
         const filePath = file.name || "AGENT.md";
 
+        // Validate AGENT.md is a real text file, not a renamed binary
+        if (filePath === "AGENT.md") {
+          try {
+            assertFileIsText(filePath, new Uint8Array(buffer));
+          } catch (e: any) {
+            return errorResponse(e.message, 400);
+          }
+          agentMdText = new TextDecoder().decode(buffer);
+        }
+
         const storageId = await ctx.storage.store(file);
         const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
         const sha256 = Array.from(new Uint8Array(hashBuffer))
           .map((b) => b.toString(16).padStart(2, "0"))
           .join("");
-        if (filePath === "AGENT.md") {
-          agentMdText = new TextDecoder().decode(buffer);
-        }
         zipEntries.push({ path: filePath, buffer });
         fileEntries.push({
           path: filePath,

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -2,7 +2,7 @@ import { httpAction } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import { jsonResponse, errorResponse, getSearchParams, resolveTokenToUser, checkHttpRateLimit } from "./shared";
 import { parseDependencySpec, satisfiesVersion } from "../lib/versionSpec";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateRoleFiles, assertRoleFileIsText, MAX_FILE_SIZE } from "../lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateRoleFiles, assertFileIsText, MAX_FILE_SIZE } from "../lib/publishValidation";
 import { parseFrontmatter, extractName } from "../lib/frontmatter";
 import { createZipBlob } from "../lib/zip";
 
@@ -282,7 +282,7 @@ export const publishRole = httpAction(async (ctx, request) => {
 
         // Reject binary files — roles only allow text
         try {
-          assertRoleFileIsText(filePath, new Uint8Array(buffer));
+          assertFileIsText(filePath, new Uint8Array(buffer));
         } catch (e: any) {
           return errorResponse(e.message, 400);
         }

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1,7 +1,7 @@
 import { httpAction } from "../_generated/server";
 import { api, internal } from "../_generated/api";
 import { jsonResponse, errorResponse, getSearchParams, resolveTokenToUser, hashToken, checkHttpRateLimit } from "./shared";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, MAX_FILE_SIZE } from "../lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, assertFileIsText, MAX_FILE_SIZE } from "../lib/publishValidation";
 import { parseFrontmatter, extractName } from "../lib/frontmatter";
 import { createZipBlob } from "../lib/zip";
 
@@ -148,17 +148,25 @@ export const publishSkill = httpAction(async (ctx, request) => {
         if (file.size > MAX_FILE_SIZE) {
           return errorResponse(`File '${file.name}' exceeds ${MAX_FILE_SIZE / 1024}KB limit`, 400);
         }
+        const buffer = await file.arrayBuffer();
+        const filePath = file.name || "SKILL.md";
+
+        // Validate SKILL.md is a real text file, not a renamed binary
+        if (filePath === "SKILL.md") {
+          try {
+            assertFileIsText(filePath, new Uint8Array(buffer));
+          } catch (e: any) {
+            return errorResponse(e.message, 400);
+          }
+          skillMdText = new TextDecoder().decode(buffer);
+        }
+
         const storageId = await ctx.storage.store(file);
         // Compute SHA-256
-        const buffer = await file.arrayBuffer();
         const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
         const sha256 = Array.from(new Uint8Array(hashBuffer))
           .map((b) => b.toString(16).padStart(2, "0"))
           .join("");
-        const filePath = file.name || "SKILL.md";
-        if (filePath === "SKILL.md") {
-          skillMdText = new TextDecoder().decode(buffer);
-        }
         zipEntries.push({ path: filePath, buffer });
         fileEntries.push({
           path: filePath,
@@ -175,6 +183,12 @@ export const publishSkill = httpAction(async (ctx, request) => {
 
   if (fileEntries.length === 0) {
     return errorResponse("At least one file is required", 400);
+  }
+
+  try {
+    validateFiles(fileEntries);
+  } catch (e: any) {
+    return errorResponse(e.message, 400);
   }
 
   // Validate frontmatter name matches slug

--- a/convex/lib/publishValidation.test.ts
+++ b/convex/lib/publishValidation.test.ts
@@ -7,6 +7,7 @@ import {
   validateFiles,
   validateRoleFiles,
   validateFrontmatterName,
+  assertFileIsText,
   assertRoleFileIsText,
   MAX_SLUG_LENGTH,
   MAX_DISPLAY_NAME_LENGTH,
@@ -169,8 +170,9 @@ describe("validateFiles", () => {
   it("accepts any file extension alongside SKILL.md", () => {
     const skill = { path: "SKILL.md", size: 100 };
     expect(() => validateFiles([skill, { path: "script.js", size: 100 }])).not.toThrow();
-    expect(() => validateFiles([skill, { path: "Makefile", size: 100 }])).not.toThrow();
     expect(() => validateFiles([skill, { path: "handler.py", size: 100 }])).not.toThrow();
+    expect(() => validateFiles([skill, { path: "Makefile", size: 100 }])).not.toThrow();
+    expect(() => validateFiles([skill, { path: "image.png", size: 100 }])).not.toThrow();
   });
 });
 
@@ -227,60 +229,85 @@ describe("validateFrontmatterName", () => {
   });
 });
 
-describe("assertRoleFileIsText", () => {
+describe("assertFileIsText", () => {
   it("accepts valid markdown text", () => {
     const buf = new TextEncoder().encode("# My Role\n\nThis is a role file.");
-    expect(() => assertRoleFileIsText("ROLE.md", buf)).not.toThrow();
+    expect(() => assertFileIsText("ROLE.md", buf)).not.toThrow();
   });
 
   it("accepts empty file", () => {
-    expect(() => assertRoleFileIsText("ROLE.md", new Uint8Array(0))).not.toThrow();
+    expect(() => assertFileIsText("ROLE.md", new Uint8Array(0))).not.toThrow();
   });
 
   it("accepts file with YAML frontmatter", () => {
     const buf = new TextEncoder().encode("---\ntitle: Test\n---\n# Hello");
-    expect(() => assertRoleFileIsText("ROLE.md", buf)).not.toThrow();
+    expect(() => assertFileIsText("ROLE.md", buf)).not.toThrow();
   });
 
   it("rejects file without recognized text extension", () => {
     const buf = new TextEncoder().encode("just text");
-    expect(() => assertRoleFileIsText("binary.exe", buf)).toThrow(
+    expect(() => assertFileIsText("binary.exe", buf)).toThrow(
       /does not have a recognized text file extension/,
     );
   });
 
   it("rejects PNG disguised as .md", () => {
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
-    expect(() => assertRoleFileIsText("ROLE.md", png)).toThrow(
+    expect(() => assertFileIsText("ROLE.md", png)).toThrow(
       /binary file signature/,
     );
   });
 
   it("rejects ZIP disguised as .md", () => {
     const zip = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]);
-    expect(() => assertRoleFileIsText("ROLE.md", zip)).toThrow(
+    expect(() => assertFileIsText("ROLE.md", zip)).toThrow(
       /binary file signature/,
     );
   });
 
   it("rejects PDF disguised as .md", () => {
     const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
-    expect(() => assertRoleFileIsText("ROLE.md", pdf)).toThrow(
+    expect(() => assertFileIsText("ROLE.md", pdf)).toThrow(
       /binary file signature/,
     );
   });
 
   it("rejects file with null bytes (unknown binary)", () => {
     const buf = new Uint8Array([0x41, 0x42, 0x43, 0x00, 0x44, 0x45]);
-    expect(() => assertRoleFileIsText("ROLE.md", buf)).toThrow(
+    expect(() => assertFileIsText("ROLE.md", buf)).toThrow(
       /contains null bytes/,
     );
   });
 
   it("rejects ELF binary disguised as .md", () => {
     const elf = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x02]);
-    expect(() => assertRoleFileIsText("ROLE.md", elf)).toThrow(
+    expect(() => assertFileIsText("ROLE.md", elf)).toThrow(
       /binary file signature/,
     );
+  });
+
+  it("works for SKILL.md files", () => {
+    const buf = new TextEncoder().encode("# My Skill\n\nSkill description.");
+    expect(() => assertFileIsText("SKILL.md", buf)).not.toThrow();
+  });
+
+  it("rejects binary SKILL.md", () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(() => assertFileIsText("SKILL.md", png)).toThrow(/binary file signature/);
+  });
+
+  it("works for AGENT.md files", () => {
+    const buf = new TextEncoder().encode("# My Agent\n\nAgent description.");
+    expect(() => assertFileIsText("AGENT.md", buf)).not.toThrow();
+  });
+
+  it("rejects binary AGENT.md", () => {
+    const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
+    expect(() => assertFileIsText("AGENT.md", pdf)).toThrow(/binary file signature/);
+  });
+
+  it("deprecated alias assertRoleFileIsText still works", () => {
+    const buf = new TextEncoder().encode("# Role");
+    expect(() => assertRoleFileIsText("ROLE.md", buf)).not.toThrow();
   });
 });

--- a/convex/lib/publishValidation.ts
+++ b/convex/lib/publishValidation.ts
@@ -14,7 +14,7 @@ export const MAX_FILE_SIZE = 512 * 1024; // 512 KB per file
 export const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB total
 export const MAX_FILE_COUNT = 20;
 
-// Agent-specific limits (agents include compiled binaries)
+// Agent-specific limits (agents may include compiled binaries)
 export const AGENT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
 export const AGENT_MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB total
 export const AGENT_MAX_FILE_COUNT = 50;
@@ -140,10 +140,10 @@ export function validateFrontmatterName(
 }
 
 /**
- * Verify that a ROLE.md file is actually a text file, not a renamed binary.
+ * Verify that a file is actually a text file, not a renamed binary.
  * Uses three layers: extension check, magic bytes detection, null byte heuristic.
  */
-export function assertRoleFileIsText(
+export function assertFileIsText(
   filePath: string,
   buffer: Uint8Array,
 ): void {
@@ -168,3 +168,6 @@ export function assertRoleFileIsText(
     );
   }
 }
+
+/** @deprecated Use assertFileIsText instead */
+export const assertRoleFileIsText = assertFileIsText;

--- a/convex/lib/textExtensions.test.ts
+++ b/convex/lib/textExtensions.test.ts
@@ -19,6 +19,26 @@ describe("isTextFile", () => {
     expect(isTextFile("package-lock.lock")).toBe(true);
   });
 
+  it("recognizes extensions from clawhub allowlist", () => {
+    expect(isTextFile("doc.mdx")).toBe(true);
+    expect(isTextFile("config.json5")).toBe(true);
+    expect(isTextFile("module.cjs")).toBe(true);
+    expect(isTextFile("module.mjs")).toBe(true);
+    expect(isTextFile("main.go")).toBe(true);
+    expect(isTextFile("lib.rs")).toBe(true);
+    expect(isTextFile("App.swift")).toBe(true);
+    expect(isTextFile("Main.kt")).toBe(true);
+    expect(isTextFile("Main.java")).toBe(true);
+    expect(isTextFile("Program.cs")).toBe(true);
+    expect(isTextFile("main.cpp")).toBe(true);
+    expect(isTextFile("main.c")).toBe(true);
+    expect(isTextFile("header.h")).toBe(true);
+    expect(isTextFile("header.hpp")).toBe(true);
+    expect(isTextFile("query.sql")).toBe(true);
+    expect(isTextFile("style.scss")).toBe(true);
+    expect(isTextFile("style.sass")).toBe(true);
+  });
+
   it("is case-insensitive for extensions", () => {
     expect(isTextFile("FILE.MD")).toBe(true);
     expect(isTextFile("FILE.Json")).toBe(true);

--- a/convex/lib/textExtensions.ts
+++ b/convex/lib/textExtensions.ts
@@ -4,10 +4,28 @@
  * - Frontend binary detection heuristic
  */
 export const TEXT_EXTENSIONS = new Set([
-  ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".xml", ".html", ".css",
-  ".js", ".ts", ".jsx", ".tsx", ".py", ".rb", ".sh", ".bash", ".zsh",
-  ".env", ".gitignore", ".editorconfig", ".prettierrc", ".eslintrc",
-  ".cfg", ".ini", ".conf", ".csv", ".svg", ".lock", ".log",
+  // Markdown / plain text
+  ".md", ".mdx", ".txt",
+  // Data / config
+  ".json", ".json5", ".yaml", ".yml", ".toml", ".xml", ".ini", ".cfg",
+  ".env", ".csv", ".conf",
+  // JavaScript / TypeScript
+  ".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx",
+  // Python / Ruby / Shell
+  ".py", ".rb", ".sh", ".bash", ".zsh",
+  // Compiled languages
+  ".go", ".rs", ".swift", ".kt", ".java", ".cs",
+  ".cpp", ".c", ".h", ".hpp",
+  // SQL
+  ".sql",
+  // Web
+  ".html", ".css", ".scss", ".sass",
+  // SVG
+  ".svg",
+  // Dotfiles / tooling
+  ".gitignore", ".editorconfig", ".prettierrc", ".eslintrc",
+  // Misc
+  ".lock", ".log",
 ]);
 
 export function isTextFile(filePath: string): boolean {

--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -365,16 +365,19 @@ function UploadPage() {
       return;
     }
 
-    // Verify ROLE.md is actually a text file, not a renamed binary
-    if (kind === "role") {
-      const buf = new Uint8Array(await files[0].file.arrayBuffer());
-      if (isBinaryByMagicBytes(buf)) {
-        setError("ROLE.md appears to be a binary file (detected binary file signature). Only text files are allowed.");
-        return;
-      }
-      if (containsNullBytes(buf, 8192)) {
-        setError("ROLE.md appears to be a binary file (contains null bytes). Only text files are allowed.");
-        return;
+    // Verify primary .md files are actually text, not renamed binaries
+    if (kind === "role" || kind === "skill" || kind === "agent") {
+      const mdFile = files.find((f) => f.path === primaryFile);
+      if (mdFile) {
+        const buf = new Uint8Array(await mdFile.file.arrayBuffer());
+        if (isBinaryByMagicBytes(buf)) {
+          setError(`${primaryFile} appears to be a binary file (detected binary file signature). Only text files are allowed.`);
+          return;
+        }
+        if (containsNullBytes(buf, 8192)) {
+          setError(`${primaryFile} appears to be a binary file (contains null bytes). Only text files are allowed.`);
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Expanded text extension allowlist to match clawhub (added 17 extensions: mdx, json5, cjs, mjs, go, rs, swift, kt, java, cs, cpp, c, h, hpp, sql, scss, sass)
- Generalized `assertRoleFileIsText` → `assertFileIsText` and applied same 3-layer text validation (extension check, magic bytes, null bytes) to SKILL.md and AGENT.md
- Added validation on both backend API handlers (skillsV1, agentsV1) and frontend upload page
- Binaries still allowed alongside primary .md files for skill and agent uploads
- Added `validateFiles` call to skill publish endpoint

## Test plan
- [x] All 88 unit tests pass (publishValidation, textExtensions, binaryDetection)
- [x] TypeScript compiles with no errors
- [ ] Manually test uploading a skill with a binary SKILL.md — should be rejected
- [ ] Manually test uploading an agent with a binary AGENT.md — should be rejected
- [ ] Manually test uploading a skill with valid SKILL.md + binary companion files — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)