### PR TITLE
Add ownership claim system for imported skills

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,7 +1,7 @@
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 import { auth } from "./auth";
-import { listSkills, handleGetSkill, handleGetSkillFile, publishSkill, handleDeleteSkill } from "./httpApiV1/skillsV1";
+import { listSkills, handleGetSkill, handleGetSkillFile, publishSkill, handleDeleteSkill, handleClaimSkill } from "./httpApiV1/skillsV1";
 import { listRoles, handleGetRole, handleGetRoleFile, handleResolveRoleDeps, publishRole, handleDeleteRole } from "./httpApiV1/rolesV1";
 import { listAgents, handleGetAgent, handleGetAgentFile, publishAgent, handleDeleteAgent } from "./httpApiV1/agentsV1";
 import { searchAll } from "./httpApiV1/searchV1";
@@ -24,16 +24,22 @@ http.route({ path: "/api/v1/skills", method: "GET", handler: listSkills });
 http.route({ path: "/api/v1/skills", method: "POST", handler: publishSkill });
 http.route({ path: "/api/v1/skills", method: "OPTIONS", handler: corsHandler });
 
-// Dynamic slug routes: /api/v1/skills/:slug and /api/v1/skills/:slug/file
+// Dynamic slug routes: /api/v1/skills/:slug, /api/v1/skills/:slug/file, /api/v1/skills/:slug/claim
 const skillSlugDispatcher = httpAction(async (ctx, request) => {
   const parts = new URL(request.url).pathname.split("/");
   if (parts[5] === "file") return handleGetSkillFile(ctx, request);
   return handleGetSkill(ctx, request);
 });
+const skillSlugPostDispatcher = httpAction(async (ctx, request) => {
+  const parts = new URL(request.url).pathname.split("/");
+  if (parts[5] === "claim") return handleClaimSkill(ctx, request);
+  return new Response("Not Found", { status: 404 });
+});
 const skillSlugDeleteDispatcher = httpAction(async (ctx, request) => {
   return handleDeleteSkill(ctx, request);
 });
 http.route({ pathPrefix: "/api/v1/skills/", method: "GET", handler: skillSlugDispatcher });
+http.route({ pathPrefix: "/api/v1/skills/", method: "POST", handler: skillSlugPostDispatcher });
 http.route({ pathPrefix: "/api/v1/skills/", method: "DELETE", handler: skillSlugDeleteDispatcher });
 http.route({ pathPrefix: "/api/v1/skills/", method: "OPTIONS", handler: corsHandler });
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -99,6 +99,7 @@ export const publishSkill = httpAction(async (ctx, request) => {
   let changelog: string;
   let customTags: string[] | undefined;
   let dependencies: { skills?: string[] } | undefined;
+  let importSource: { source: string; originalOwnerHandle: string; originalOwnerGithubId: string } | undefined;
   let skillMdText: string | undefined;
   const fileEntries: Array<{
     path: string;
@@ -124,6 +125,15 @@ export const publishSkill = httpAction(async (ctx, request) => {
         dependencies = JSON.parse(depsStr);
       } catch {
         return errorResponse("dependencies must be valid JSON: {\"skills\": [...]}", 400);
+      }
+    }
+
+    const importSourceStr = formData.get("importSource") as string | null;
+    if (importSourceStr) {
+      try {
+        importSource = JSON.parse(importSourceStr);
+      } catch {
+        // Ignore invalid importSource
       }
     }
 
@@ -221,6 +231,7 @@ export const publishSkill = httpAction(async (ctx, request) => {
       changelog,
       files: fileEntries as any,
       dependencies,
+      importSource,
       customTags,
       skillMdText,
       zipStorageId,
@@ -254,6 +265,31 @@ export async function handleDeleteSkill(ctx: any, request: Request): Promise<Res
   }
 }
 
+/**
+ * POST /api/v1/skills/:slug/claim — claim ownership of an imported skill
+ */
+export async function handleClaimSkill(ctx: any, request: Request): Promise<Response> {
+  const rateLimited = await checkHttpRateLimit(ctx, request, "write");
+  if (rateLimited) return rateLimited;
+
+  const authResult = await resolveTokenToUser(ctx, request);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const url = new URL(request.url);
+  const parts = url.pathname.split("/");
+  // /api/v1/skills/:slug/claim
+  const slug = parts[parts.length - 2];
+  if (!slug) return errorResponse("Slug required", 400);
+
+  try {
+    const result = await ctx.runMutation(internal.skills.claimSkillInternal, { slug, userId });
+    return jsonResponse(result);
+  } catch (e: any) {
+    return errorResponse(e.message || "Claim failed", 400);
+  }
+}
+
 // ─── Formatters ──────────────────────────────────────────────────────────────
 
 function formatSkill(skill: any) {
@@ -275,6 +311,7 @@ function formatSkillDetail(skill: any) {
     owner: skill.owner,
     stats: skill.stats,
     badges: skill.badges,
+    importSource: skill.importSource ?? null,
     dependencies: skill.dependencies,
     zipUrl: skill.zipUrl ?? null,
     latestVersion: skill.latestVersion

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -69,6 +69,13 @@ export default defineSchema({
     latestVersionId: v.optional(v.id("skillVersions")),
     tags: v.any(), // Record<string, Id<"skillVersions">>
     badges,
+    importSource: v.optional(
+      v.object({
+        source: v.string(),
+        originalOwnerHandle: v.string(),
+        originalOwnerGithubId: v.string(),
+      }),
+    ),
     softDeletedAt: v.optional(v.number()),
     moderationStatus: v.optional(
       v.union(v.literal("active"), v.literal("hidden"), v.literal("removed")),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -194,6 +194,13 @@ const publishArgs = {
       skills: v.optional(v.array(v.string())),
     }),
   ),
+  importSource: v.optional(
+    v.object({
+      source: v.string(),
+      originalOwnerHandle: v.string(),
+      originalOwnerGithubId: v.string(),
+    }),
+  ),
   customTags: v.optional(v.array(v.string())),
   skillMdText: v.optional(v.string()),
   zipStorageId: v.optional(v.id("_storage")),
@@ -290,6 +297,7 @@ export const publishInternal = internalMutation({
           : undefined,
         ownerUserId: user._id,
         tags: {},
+        importSource: user.role === "admin" ? args.importSource : undefined,
         stats: { downloads: 0, stars: 0, versions: 0, comments: 0 },
         createdAt: now,
         updatedAt: now,
@@ -580,5 +588,94 @@ export const restore = mutation({
     if (!skill) throw new Error("Skill not found");
 
     await ctx.db.patch(skill._id, { softDeletedAt: undefined });
+  },
+});
+
+/**
+ * Claim ownership of an imported skill.
+ * Verifies the caller's GitHub identity matches the original ClawHub owner.
+ */
+export const claimSkill = mutation({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("User not found");
+    if (user.deactivatedAt) throw new Error("Account is deactivated");
+
+    const skill = await ctx.db
+      .query("skills")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .first();
+    if (!skill) throw new Error("Skill not found");
+    if (!skill.importSource) throw new Error("This skill was not imported and cannot be claimed");
+
+    // Look up the caller's GitHub account ID from authAccounts
+    const authAccount = await ctx.db
+      .query("authAccounts")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("userId"), userId),
+          q.eq(q.field("provider"), "github"),
+        ),
+      )
+      .first();
+    if (!authAccount) throw new Error("No linked GitHub account found");
+
+    if (authAccount.providerAccountId !== skill.importSource.originalOwnerGithubId) {
+      throw new Error("Your GitHub identity does not match the original skill owner");
+    }
+
+    await ctx.db.patch(skill._id, {
+      ownerUserId: userId,
+      importSource: undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { ok: true, slug: args.slug };
+  },
+});
+
+/**
+ * Internal claim — accepts an explicit userId (used by HTTP endpoint).
+ */
+export const claimSkillInternal = internalMutation({
+  args: { slug: v.string(), userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const user = await ctx.db.get(args.userId);
+    if (!user) throw new Error("User not found");
+    if (user.deactivatedAt) throw new Error("Account is deactivated");
+
+    const skill = await ctx.db
+      .query("skills")
+      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
+      .first();
+    if (!skill) throw new Error("Skill not found");
+    if (!skill.importSource) throw new Error("This skill was not imported and cannot be claimed");
+
+    const authAccount = await ctx.db
+      .query("authAccounts")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("userId"), args.userId),
+          q.eq(q.field("provider"), "github"),
+        ),
+      )
+      .first();
+    if (!authAccount) throw new Error("No linked GitHub account found");
+
+    if (authAccount.providerAccountId !== skill.importSource.originalOwnerGithubId) {
+      throw new Error("Your GitHub identity does not match the original skill owner");
+    }
+
+    await ctx.db.patch(skill._id, {
+      ownerUserId: args.userId,
+      importSource: undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { ok: true, slug: args.slug };
   },
 });

--- a/src/routes/skills.$slug.tsx
+++ b/src/routes/skills.$slug.tsx
@@ -40,8 +40,11 @@ function SkillDetailPage() {
     api.reports.hasReported,
     skill ? { targetId: skill._id } : "skip",
   );
+  const claimSkill = useMutation(api.skills.claimSkill);
   const navigate = useNavigate();
   const isOwner = !!(currentUser && skill && skill.ownerUserId === currentUser._id);
+  const [claiming, setClaiming] = useState(false);
+  const [claimError, setClaimError] = useState("");
   const [showReportForm, setShowReportForm] = useState(false);
   const [reportDescription, setReportDescription] = useState("");
   const [reportSubmitting, setReportSubmitting] = useState(false);
@@ -181,6 +184,42 @@ function SkillDetailPage() {
               <span className="text-gray-500">@{skill.owner.handle}</span>
             )}
           </div>
+        </div>
+      )}
+
+      {/* Imported from ClawHub badge + claim button */}
+      {skill.importSource && (
+        <div className="flex items-center gap-3 rounded-lg border border-blue-500/20 bg-blue-500/5 px-4 py-3">
+          <span className="text-sm text-blue-400">
+            Imported from {skill.importSource.source === "clawhub" ? "ClawHub" : skill.importSource.source}
+          </span>
+          {skill.importSource.originalOwnerHandle && (
+            <span className="text-sm text-gray-500">
+              (original author: @{skill.importSource.originalOwnerHandle})
+            </span>
+          )}
+          {currentUser && !isOwner && (
+            <button
+              onClick={async () => {
+                setClaiming(true);
+                setClaimError("");
+                try {
+                  await claimSkill({ slug: skill.slug });
+                } catch (e: any) {
+                  setClaimError(e.message || "Claim failed");
+                } finally {
+                  setClaiming(false);
+                }
+              }}
+              disabled={claiming}
+              className="ml-auto rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50 transition-colors"
+            >
+              {claiming ? "Claiming..." : "Claim Ownership"}
+            </button>
+          )}
+          {claimError && (
+            <span className="text-sm text-red-400">{claimError}</span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add `importSource` field to skills schema for tracking original ClawHub owners (handle + GitHub ID)
- Restrict `importSource` writes to admin users only in `publishInternal`
- Add `claimSkill` / `claimSkillInternal` mutations — verifies caller's GitHub ID from `authAccounts` matches `importSource.originalOwnerGithubId`
- Add `POST /api/v1/skills/:slug/claim` HTTP endpoint
- Show "Imported from ClawHub" banner with original author handle and "Claim Ownership" button on skill detail page

## Test plan
- [ ] Deploy schema change and verify `importSource` field is accepted
- [ ] Publish a test skill with `importSource` using an admin account — verify it's stored
- [ ] Publish with a non-admin account — verify `importSource` is silently ignored
- [ ] Log in as matching GitHub user and verify claim succeeds
- [ ] Log in as non-matching user and verify claim is rejected
- [ ] Verify "Imported from ClawHub" banner renders on skill detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)