### PR TITLE
Align skill publish limits with agent limits

### DIFF
--- a/convex/lib/publishValidation.test.ts
+++ b/convex/lib/publishValidation.test.ts
@@ -133,7 +133,7 @@ describe("validateFiles", () => {
         size: 100,
       })),
     ];
-    expect(() => validateFiles(files)).toThrow(/Maximum 20 files/);
+    expect(() => validateFiles(files)).toThrow(/Maximum 50 files/);
   });
 
   it("accepts exactly MAX_FILE_COUNT files", () => {
@@ -149,17 +149,13 @@ describe("validateFiles", () => {
 
   it("rejects oversized file", () => {
     const files = [{ path: "SKILL.md", size: MAX_FILE_SIZE + 1 }];
-    expect(() => validateFiles(files)).toThrow(/exceeds 512KB/);
+    expect(() => validateFiles(files)).toThrow(/exceeds 10MB/);
   });
 
   it("accepts file at max size", () => {
     const files = [{ path: "SKILL.md", size: MAX_FILE_SIZE }];
     expect(() => validateFiles(files)).not.toThrow();
   });
-
-  // Total size limit (50 MB) is unreachable with current per-file (512 KB)
-  // and count (20) limits: 20 × 512 KB = 10 MB < 50 MB.
-  // The limit exists as a safety net if per-file or count limits are raised.
 
   it("requires SKILL.md", () => {
     expect(() => validateFiles([{ path: "script.js", size: 100 }])).toThrow(

--- a/convex/lib/publishValidation.ts
+++ b/convex/lib/publishValidation.ts
@@ -10,9 +10,9 @@ const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*$/;
 export const MAX_SLUG_LENGTH = 64;
 export const MAX_DISPLAY_NAME_LENGTH = 128;
 export const MAX_CHANGELOG_LENGTH = 10_000;
-export const MAX_FILE_SIZE = 512 * 1024; // 512 KB per file
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
 export const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB total
-export const MAX_FILE_COUNT = 20;
+export const MAX_FILE_COUNT = 50;
 
 // Agent-specific limits (agents may include compiled binaries)
 export const AGENT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
@@ -63,7 +63,7 @@ export function validateFiles(
   for (const file of files) {
     if (file.size > MAX_FILE_SIZE) {
       throw new Error(
-        `File '${file.path}' exceeds ${MAX_FILE_SIZE / 1024}KB limit`,
+        `File '${file.path}' exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`,
       );
     }
     totalSize += file.size;


### PR DESCRIPTION
## Summary
- Increase skill per-file size limit from 512 KB to **10 MB** (matching agents)
- Increase skill max file count from 20 to **50** (matching agents)
- Update error message to display MB instead of KB
- Update test expectations to match new limits

## Test plan
- [x] `vitest run convex/lib/publishValidation.test.ts` — all 50 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)