### PR TITLE
Allow moderators to set importSource when publishing skills

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -297,7 +297,7 @@ export const publishInternal = internalMutation({
           : undefined,
         ownerUserId: user._id,
         tags: {},
-        importSource: user.role === "admin" ? args.importSource : undefined,
+        importSource: user.role === "admin" || user.role === "moderator" ? args.importSource : undefined,
         stats: { downloads: 0, stars: 0, versions: 0, comments: 0 },
         createdAt: now,
         updatedAt: now,


### PR DESCRIPTION
## Summary
- Previously only `admin` role could set `importSource` when publishing a skill
- Now `moderator` role can also set `importSource`, enabling them to import skills from external sources like ClawHub

## Test plan
- [ ] Verify moderator users can publish skills with `importSource` set
- [ ] Verify non-admin/non-moderator users still cannot set `importSource`
- [ ] Verify admin users are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)