### PR TITLE
Improve claim ownership UX for imported skills

### DIFF
--- a/src/routes/skills.$slug.tsx
+++ b/src/routes/skills.$slug.tsx
@@ -198,7 +198,7 @@ function SkillDetailPage() {
               (original author: @{skill.importSource.originalOwnerHandle})
             </span>
           )}
-          {currentUser && !isOwner && (
+          {currentUser && !isOwner && currentUser.handle === skill.importSource.originalOwnerHandle && (
             <button
               onClick={async () => {
                 setClaiming(true);
@@ -206,7 +206,12 @@ function SkillDetailPage() {
                 try {
                   await claimSkill({ slug: skill.slug });
                 } catch (e: any) {
-                  setClaimError(e.message || "Claim failed");
+                  const raw = e.message || "Claim failed";
+                  const cleaned = raw
+                    .replace(/^\[CONVEX [^\]]*\]\s*(\[Request ID: [^\]]*\]\s*)?Server Error\s*Uncaught Error:\s*/i, "")
+                    .replace(/[\s\n]+at\s+\S+\s*\(.*$/s, "")
+                    .trim();
+                  setClaimError(cleaned);
                 } finally {
                   setClaiming(false);
                 }


### PR DESCRIPTION
## Summary
- Hide the "Claim Ownership" button when the signed-in user's handle doesn't match the imported skill's `originalOwnerHandle`
- Clean up Convex error messages by stripping internal prefixes (e.g. `[CONVEX M(...)]`, `[Request ID: ...]`, `Server Error Uncaught Error:`, stack traces), using the same pattern as `upload.tsx`

## Test plan
- [ ] Verify claim button is hidden for users whose handle doesn't match the original owner
- [ ] Verify claim button still appears for the matching user
- [ ] Verify error messages display cleanly without Convex internals if a claim fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)