### PR TITLE
Display total count on list pages and add backfill mutation

### DIFF
--- a/convex/counters.ts
+++ b/convex/counters.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { query, internalMutation } from "./_generated/server";
+import { query, internalMutation, mutation } from "./_generated/server";
 
 /**
  * Increment or decrement a named counter.
@@ -25,6 +25,29 @@ export const adjust = internalMutation({
         count: Math.max(0, args.delta),
       });
     }
+  },
+});
+
+export const backfill = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const tables = ["skills", "roles", "agents"] as const;
+    const results: Record<string, number> = {};
+    for (const table of tables) {
+      const rows = await ctx.db.query(table).collect();
+      const count = rows.filter((r: any) => !r.softDeletedAt).length;
+      const existing = await ctx.db
+        .query("counters")
+        .withIndex("by_name", (q) => q.eq("name", table))
+        .first();
+      if (existing) {
+        await ctx.db.patch(existing._id, { count });
+      } else {
+        await ctx.db.insert("counters", { name: table, count });
+      }
+      results[table] = count;
+    }
+    return results;
   },
 });
 

--- a/src/routes/agents.index.tsx
+++ b/src/routes/agents.index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useConvexAuth, useMutation } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { usePaginatedQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useSEO } from "../lib/useSEO";
@@ -33,6 +33,7 @@ function AgentsPage() {
     { initialNumItems: 1000 },
   );
   const toggleStar = useMutation(api.stars.toggle);
+  const counts = useQuery(api.counters.getCounts, {});
 
   const canLoadMore = status === "CanLoadMore";
   const isLoading = status === "LoadingFirstPage";
@@ -60,6 +61,9 @@ function AgentsPage() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Agents
+          {counts?.agents != null && (
+            <span className="ml-2 text-base font-normal text-gray-500">({counts.agents.toLocaleString()})</span>
+          )}
         </h1>
         <Link
           to="/upload"

--- a/src/routes/roles.index.tsx
+++ b/src/routes/roles.index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useConvexAuth, useMutation } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { usePaginatedQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useSEO } from "../lib/useSEO";
@@ -33,6 +33,7 @@ function RolesPage() {
     { initialNumItems: 1000 },
   );
   const toggleStar = useMutation(api.stars.toggle);
+  const counts = useQuery(api.counters.getCounts, {});
 
   const canLoadMore = status === "CanLoadMore";
   const isLoading = status === "LoadingFirstPage";
@@ -60,6 +61,9 @@ function RolesPage() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Roles
+          {counts?.roles != null && (
+            <span className="ml-2 text-base font-normal text-gray-500">({counts.roles.toLocaleString()})</span>
+          )}
         </h1>
         <Link
           to="/upload"

--- a/src/routes/skills.index.tsx
+++ b/src/routes/skills.index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useConvexAuth, useMutation } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { usePaginatedQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useSEO } from "../lib/useSEO";
@@ -33,6 +33,7 @@ function SkillsPage() {
     { initialNumItems: 1000 },
   );
   const toggleStar = useMutation(api.stars.toggle);
+  const counts = useQuery(api.counters.getCounts, {});
 
   const canLoadMore = status === "CanLoadMore";
   const isLoading = status === "LoadingFirstPage";
@@ -60,6 +61,9 @@ function SkillsPage() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Skills
+          {counts?.skills != null && (
+            <span className="ml-2 text-base font-normal text-gray-500">({counts.skills.toLocaleString()})</span>
+          )}
         </h1>
         <Link
           to="/upload"


### PR DESCRIPTION
## Summary
- Display total count next to heading on skills, roles, and agents list pages using `counters.getCounts`
- Include `backfill` mutation for seeding counter values on prod after deploy

## Post-deploy steps
After merging and CI deploy, run:
```bash
npx convex run counters:backfill '{}' --prod
```

## Test plan
- [ ] Verify count appears next to "Skills", "Roles", "Agents" headings
- [ ] Run backfill on prod and verify correct counts
- [ ] Remove backfill mutation in follow-up after seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)