### PR TITLE
Match count font size to page title

### DIFF
--- a/src/routes/agents.index.tsx
+++ b/src/routes/agents.index.tsx
@@ -62,7 +62,7 @@ function AgentsPage() {
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Agents
           {counts?.agents != null && (
-            <span className="ml-2 text-base font-normal text-gray-500">({counts.agents.toLocaleString()})</span>
+            <span className="ml-2 font-normal text-gray-500">({counts.agents.toLocaleString()})</span>
           )}
         </h1>
         <Link

--- a/src/routes/roles.index.tsx
+++ b/src/routes/roles.index.tsx
@@ -62,7 +62,7 @@ function RolesPage() {
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Roles
           {counts?.roles != null && (
-            <span className="ml-2 text-base font-normal text-gray-500">({counts.roles.toLocaleString()})</span>
+            <span className="ml-2 font-normal text-gray-500">({counts.roles.toLocaleString()})</span>
           )}
         </h1>
         <Link

--- a/src/routes/skills.index.tsx
+++ b/src/routes/skills.index.tsx
@@ -62,7 +62,7 @@ function SkillsPage() {
         <h1 className="text-2xl md:text-3xl font-bold text-white">
           Skills
           {counts?.skills != null && (
-            <span className="ml-2 text-base font-normal text-gray-500">({counts.skills.toLocaleString()})</span>
+            <span className="ml-2 font-normal text-gray-500">({counts.skills.toLocaleString()})</span>
           )}
         </h1>
         <Link


### PR DESCRIPTION
## Summary
- Remove `text-base` from count spans so they inherit the `h1` font size (`text-2xl md:text-3xl`)
- Count still uses `font-normal text-gray-500` to differentiate from the bold white title

## Test plan
- [ ] Verify count text on skills, roles, and agents pages matches title size

🤖 Generated with [Claude Code](https://claude.com/claude-code)