### PR TITLE
Add batched deleteAllFiles internal mutation

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as auth from "../auth.js";
 import type * as comments from "../comments.js";
 import type * as counters from "../counters.js";
 import type * as crons from "../crons.js";
+import type * as deleteAllFiles from "../deleteAllFiles.js";
 import type * as downloads from "../downloads.js";
 import type * as files from "../files.js";
 import type * as http from "../http.js";
@@ -59,6 +60,7 @@ declare const fullApi: ApiFromModules<{
   comments: typeof comments;
   counters: typeof counters;
   crons: typeof crons;
+  deleteAllFiles: typeof deleteAllFiles;
   downloads: typeof downloads;
   files: typeof files;
   http: typeof http;

--- a/convex/deleteAllFiles.ts
+++ b/convex/deleteAllFiles.ts
@@ -1,0 +1,25 @@
+import { internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const BATCH_SIZE = 1000;
+
+export const run = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const files = await ctx.db.system
+      .query("_storage")
+      .take(BATCH_SIZE);
+
+    if (files.length === 0) {
+      console.log("All files deleted.");
+      return;
+    }
+
+    for (const file of files) {
+      await ctx.storage.delete(file._id);
+    }
+
+    console.log(`Deleted ${files.length} files, scheduling next batch...`);
+    await ctx.scheduler.runAfter(0, internal.deleteAllFiles.run);
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `convex/deleteAllFiles.ts` with a batched internal mutation that deletes all Convex storage files
- Processes 1000 files per batch and self-schedules until all files are deleted
- Intended as a temporary utility for cleaning up storage in preview/prod deployments

## Usage
```bash
npx convex run --preview-name <name> --push deleteAllFiles:run
npx convex run --prod --push deleteAllFiles:run
```

## Test plan
- [ ] Deploy to preview and verify it deletes all storage files
- [ ] Remove the file after cleanup is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)