### PR TITLE
Fix skill publish links defaulting to role mode

### DIFF
--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -206,7 +206,7 @@ function UserContent({ userId }: { userId: string; handle?: string }) {
                 <div className="flex items-center gap-2 shrink-0">
                   <Link
                     to="/upload"
-                    search={{ updateSlug: s.slug }}
+                    search={{ updateSlug: s.slug, kind: "skill" }}
                     className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
                   >
                     New Version

--- a/src/routes/skills.index.tsx
+++ b/src/routes/skills.index.tsx
@@ -67,6 +67,7 @@ function SkillsPage() {
         </h1>
         <Link
           to="/upload"
+          search={{ kind: "skill" }}
           className="rounded bg-orange-500 px-4 py-2 text-sm font-medium text-white hover:bg-orange-600"
         >
           Publish Skill


### PR DESCRIPTION
## Summary
- Add missing `kind: "skill"` search param to the "Publish Skill" link on the skills list page
- Add missing `kind: "skill"` to the "New Version" link for skills on the dashboard

Both links were navigating to `/upload` without specifying the kind, causing the upload page to default to role mode.

## Test plan
- [ ] Click "Publish Skill" on `/skills` — verify upload page opens in Skill mode
- [ ] Click "New Version" on a skill in the dashboard — verify upload page opens in Skill mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)