### PR TITLE
Update documentation for memory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 StrawHub is the registry for [StrawPot](https://strawpot.com) — the open-source framework for role-based AI agents.
 
-Discover, publish, and install **roles**, **skills**, and **agents** that power StrawPot.
+Discover, publish, and install **roles**, **skills**, **agents**, and **memories** that power StrawPot.
 
 ```
 # CrewAI: 40 lines of Python to define a 2-agent team
@@ -80,6 +80,11 @@ CLI runtimes that execute roles. Each agent bridges StrawPot to a specific AI pl
 
 Examples: `claude_code` · `codex` · `gemini`
 
+### Memory
+Persistent memory banks that store knowledge, context, and learned patterns across agent sessions.
+
+Examples: `project-context` · `code-patterns` · `team-decisions`
+
 ### Dependencies
 Roles and skills declare dependencies under `metadata.strawpot.dependencies`. A role can depend on skills (capabilities it needs) and other roles (sub-agents it delegates to). Dependencies are resolved automatically on install.
 
@@ -138,7 +143,7 @@ Instructions for the agent...
 - [x] Skills registry
 - [x] Roles registry
 - [x] Agents registry
-- [ ] Memory storage
+- [x] Memories registry
 
 ## Documentation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@
 
 Command-line client for [StrawHub](https://strawhub.dev), the public registry for [StrawPot](https://strawpot.com) agents.
 
-Discover, install, publish, and manage reusable **skills**, **roles**, and **agents** — with recursive dependency resolution.
+Discover, install, publish, and manage reusable **skills**, **roles**, **agents**, and **memories** — with recursive dependency resolution.
 
 ## Installation
 
@@ -17,7 +17,7 @@ pip install strawhub
 ## Quick Start
 
 ```bash
-# Search for skills, roles, and agents
+# Search for skills, roles, agents, and memories
 strawhub search "code review"
 
 # Install a skill (dependencies resolved automatically)
@@ -78,17 +78,17 @@ See the [project file documentation](../docs/project-file.md) for full details.
 
 | Command | Description |
 |---------|-------------|
-| `search <query>` | Search for skills, roles, and agents |
-| `info skill\|role\|agent <slug>` | Show detail for a skill, role, or agent |
-| `list` | List all available skills, roles, and agents |
-| `star skill\|role\|agent <slug>` | Star a skill, role, or agent |
-| `unstar skill\|role <slug>` | Unstar a skill or role |
+| `search <query>` | Search for skills, roles, agents, and memories |
+| `info skill\|role\|agent\|memory <slug>` | Show detail for a skill, role, agent, or memory |
+| `list` | List all available skills, roles, agents, and memories |
+| `star skill\|role\|agent\|memory <slug>` | Star a skill, role, agent, or memory |
+| `unstar skill\|role\|agent\|memory <slug>` | Unstar a skill, role, agent, or memory |
 
 ### Publishing
 
 | Command | Description |
 |---------|-------------|
-| `publish skill\|role <path>` | Publish to the registry |
+| `publish skill\|role\|agent\|memory <path>` | Publish to the registry |
 
 ### Runtime
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 1. [Repository README](../README.md) — local setup and project overview
 2. [Quickstart](quickstart.md) — end-to-end workflow: search, install, publish
 3. [Architecture](architecture.md) — how the web app, Convex backend, and CLI fit together
-4. [Content Format](content-format.md) — SKILL.md and ROLE.md structure and metadata
+4. [Content Format](content-format.md) — SKILL.md, ROLE.md, AGENT.md, and MEMORY.md structure and metadata
 5. [CLI Reference](cli.md) — all commands, flags, configuration, and lockfile details
 6. [HTTP API](http-api.md) — REST endpoints used by the CLI and third-party integrations
 7. [Authentication](auth.md) — GitHub OAuth and API tokens

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,10 +17,10 @@ System overview: web app + Convex backend + Python CLI.
 
 ## Data + Storage
 
-Two content types: **skills** and **roles**, both versioned bundles of text files stored in Convex `_storage`.
+Four content types: **skills**, **roles**, **agents**, and **memories**, all versioned bundles of files stored in Convex `_storage`. Skills and roles are text-only; agents and memories also support binary files.
 
-Metadata is extracted from YAML frontmatter in SKILL.md / ROLE.md at publish time.
-Stats (downloads, stars, comments) live on the `skills` and `roles` tables.
+Metadata is extracted from YAML frontmatter in SKILL.md / ROLE.md / AGENT.md / MEMORY.md at publish time.
+Stats (downloads, stars, comments) live on the `skills`, `roles`, `agents`, and `memories` tables.
 Embeddings (OpenAI, 1536 dimensions) are stored separately for vector search.
 
 ## Main Flows
@@ -28,7 +28,7 @@ Embeddings (OpenAI, 1536 dimensions) are stored separately for vector search.
 ### Browse (web)
 
 UI fetches content metadata + latest version via Convex queries.
-Renders SKILL.md / ROLE.md as Markdown with a frontmatter summary table.
+Renders SKILL.md / ROLE.md / AGENT.md / MEMORY.md as Markdown with a frontmatter summary table.
 Version history, download counts, and star counts are shown on detail pages.
 
 ### Search (HTTP)
@@ -51,7 +51,7 @@ Install state is tracked via a lockfile (`.strawpot/strawpot.lock`).
 
 ### Publish (CLI + web)
 
-- **CLI**: `POST /api/v1/skills` or `POST /api/v1/roles` (multipart, Bearer token)
+- **CLI**: `POST /api/v1/skills`, `POST /api/v1/roles`, `POST /api/v1/agents`, or `POST /api/v1/memories` (multipart, Bearer token)
 - **Web**: drag-and-drop files or GitHub import (paste a repo URL, files are fetched via GitHub Contents API)
 
 Version monotonicity is enforced — new versions must be strictly greater than the latest.
@@ -76,7 +76,9 @@ strawhub/
 │   ├── schema.ts           # Database schema
 │   ├── http.ts             # HTTP route definitions
 │   ├── skills.ts           # Skill queries/mutations
-│   └── roles.ts            # Role queries/mutations
+│   ├── roles.ts            # Role queries/mutations
+│   ├── agents.ts           # Agent queries/mutations
+│   └── memories.ts         # Memory queries/mutations
 ├── cli/                    # Python CLI
 │   ├── src/strawhub/       # CLI source (Click-based)
 │   └── tests/              # CLI unit tests

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,9 +20,9 @@ strawhub [--version] [--help] <command>
 | [`uninstall`](#uninstall) | Remove a package and clean up orphaned dependencies |
 | [`update`](#update) | Update packages to their latest versions |
 | [`init`](#init) | Create `strawpot.toml` from installed packages |
-| [`search`](#search) | Search for skills, roles, and agents |
+| [`search`](#search) | Search for skills, roles, agents, and memories |
 | [`info`](#info) | Show detailed information about a package |
-| [`list`](#list) | List available skills and roles |
+| [`list`](#list) | List available skills, roles, agents, and memories |
 | [`resolve`](#resolve) | Resolve a package to its installed path and dependencies |
 | [`publish`](#publish) | Publish a package to the registry |
 | [`install-tools`](#install-tools) | Install system tools declared by packages |
@@ -311,10 +311,10 @@ strawhub install-tools --global
 
 ### `search`
 
-Search for skills, roles, and agents in the registry.
+Search for skills, roles, agents, and memories in the registry.
 
 ```bash
-strawhub search <query> [--kind skill|role|all] [--limit N] [--json]
+strawhub search <query> [--kind skill|role|agent|memory|all] [--limit N] [--json]
 ```
 
 | Argument | Description |
@@ -323,7 +323,7 @@ strawhub search <query> [--kind skill|role|all] [--limit N] [--json]
 
 | Option | Description |
 |--------|-------------|
-| `--kind` | Filter by type: `skill`, `role`, or `all` (default: `all`) |
+| `--kind` | Filter by type: `skill`, `role`, `agent`, `memory`, or `all` (default: `all`) |
 | `--limit` | Maximum results, 1–100 (default: `20`) |
 | `--json` | Output raw JSON |
 
@@ -339,11 +339,13 @@ strawhub search "agent" --json
 
 ### `info`
 
-Show detailed information about a skill or role.
+Show detailed information about a skill, role, agent, or memory.
 
 ```bash
 strawhub info skill <slug> [--file PATH] [--json]
 strawhub info role <slug> [--file PATH] [--json]
+strawhub info agent <slug> [--file PATH] [--json]
+strawhub info memory <slug> [--file PATH] [--json]
 ```
 
 | Argument | Description |
@@ -352,7 +354,7 @@ strawhub info role <slug> [--file PATH] [--json]
 
 | Option | Description |
 |--------|-------------|
-| `--file <path>` | View raw content of a specific file (e.g. `SKILL.md`, `ROLE.md`) |
+| `--file <path>` | View raw content of a specific file (e.g. `SKILL.md`, `ROLE.md`, `AGENT.md`, `MEMORY.md`) |
 | `--json` | Output raw JSON |
 
 Without `--file`, displays a formatted summary: name, owner, description, latest version, published date, changelog, files, dependencies, and download/star counts.
@@ -362,6 +364,8 @@ Without `--file`, displays a formatted summary: name, owner, description, latest
 ```bash
 strawhub info skill code-review
 strawhub info role implementer --json
+strawhub info agent claude-code
+strawhub info memory project-context
 strawhub info skill code-review --file SKILL.md
 ```
 
@@ -369,15 +373,15 @@ strawhub info skill code-review --file SKILL.md
 
 ### `list`
 
-List available skills and roles from the registry.
+List available skills, roles, agents, and memories from the registry.
 
 ```bash
-strawhub list [--kind skills|roles|all] [--limit N] [--sort updated|downloads|stars] [--json]
+strawhub list [--kind skills|roles|agents|memories|all] [--limit N] [--sort updated|downloads|stars] [--json]
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--kind` | Filter by type: `skills`, `roles`, or `all` (default: `all`) |
+| `--kind` | Filter by type: `skills`, `roles`, `agents`, `memories`, or `all` (default: `all`) |
 | `--limit` | Maximum results, 1–200 (default: `50`) |
 | `--sort` | Sort order: `updated`, `downloads`, or `stars` (default: `updated`) |
 | `--json` | Output raw JSON |
@@ -465,16 +469,18 @@ strawhub resolve skill git-workflow --global
 
 ### `publish`
 
-Publish a skill or role to the StrawHub registry. Requires authentication (`strawhub login`).
+Publish a skill, role, agent, or memory to the StrawHub registry. Requires authentication (`strawhub login`).
 
 ```bash
 strawhub publish skill [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
 strawhub publish role [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
+strawhub publish agent [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
+strawhub publish memory [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `<path>` | Directory containing `SKILL.md` or `ROLE.md` (default: `.`) |
+| `<path>` | Directory containing the main markdown file (`SKILL.md`, `ROLE.md`, `AGENT.md`, or `MEMORY.md`) (default: `.`) |
 
 | Option | Description |
 |--------|-------------|
@@ -482,7 +488,7 @@ strawhub publish role [<path>] [--version <ver>] [--changelog <text>] [--tag <ta
 | `--changelog <text>` | Changelog text for this version |
 | `--tag <tag>` | Custom tag (can be specified multiple times) |
 
-The directory must contain a `SKILL.md` (for skills) or `ROLE.md` (for roles) with valid YAML frontmatter including at least `name` (the slug). All files in the directory are included in the published package (dotfiles are skipped).
+The directory must contain the appropriate main file (`SKILL.md`, `ROLE.md`, `AGENT.md`, or `MEMORY.md`) with valid YAML frontmatter including at least `name` (the slug). All files in the directory are included in the published package (dotfiles are skipped).
 
 **Frontmatter requirements:**
 
@@ -509,6 +515,12 @@ strawhub publish role ./my-role --version 2.0.0 --changelog "Major rewrite"
 
 # Publish with tags
 strawhub publish skill --tag python --tag testing
+
+# Publish an agent
+strawhub publish agent ./my-agent --version 1.0.0
+
+# Publish a memory
+strawhub publish memory ./my-memory --version 1.0.0
 ```
 
 ---
@@ -517,20 +529,24 @@ strawhub publish skill --tag python --tag testing
 
 ### `star`
 
-Star a skill or role. Requires authentication.
+Star a skill, role, agent, or memory. Requires authentication.
 
 ```bash
 strawhub star skill <slug>
 strawhub star role <slug>
+strawhub star agent <slug>
+strawhub star memory <slug>
 ```
 
 ### `unstar`
 
-Remove a star from a skill or role. Requires authentication.
+Remove a star from a skill, role, agent, or memory. Requires authentication.
 
 ```bash
 strawhub unstar skill <slug>
 strawhub unstar role <slug>
+strawhub unstar agent <slug>
+strawhub unstar memory <slug>
 ```
 
 ---
@@ -575,11 +591,13 @@ These commands require admin privileges.
 
 ### `delete`
 
-Soft-delete a skill or role from the registry.
+Soft-delete a skill, role, agent, or memory from the registry.
 
 ```bash
 strawhub delete skill <slug> [--yes]
 strawhub delete role <slug> [--yes]
+strawhub delete agent <slug> [--yes]
+strawhub delete memory <slug> [--yes]
 ```
 
 | Option | Description |

--- a/docs/content-format.md
+++ b/docs/content-format.md
@@ -1,6 +1,6 @@
 # Content Format
 
-StrawHub hosts two content types: **skills** and **roles**. Both are markdown files with YAML frontmatter.
+StrawHub hosts four content types: **skills**, **roles**, **agents**, and **memories**. All use markdown files with YAML frontmatter. Agents and memories also support binary files.
 
 ## Skills
 
@@ -89,6 +89,97 @@ Role instructions for the agent...
 
 Roles can depend on both skills and other roles.
 
+## Agents
+
+An agent is a CLI runtime wrapper that bridges StrawPot to a specific AI platform:
+
+- **Required:** `AGENT.md` — YAML frontmatter + markdown body
+- **Optional:** compiled binaries and supporting files
+
+### AGENT.md
+
+```yaml
+---
+name: claude-code
+description: "Claude Code agent"
+metadata:
+  version: "0.1.0"
+  strawpot:
+    bin:
+      macos: strawpot_claude_code
+      linux: strawpot_claude_code
+    tools:
+      claude:
+        description: Claude Code CLI
+        install:
+          macos: npm install -g @anthropic-ai/claude-code
+          linux: npm install -g @anthropic-ai/claude-code
+    params:
+      model:
+        type: string
+        default: claude-sonnet-4-6
+        description: Model to use
+    env:
+      ANTHROPIC_API_KEY:
+        required: false
+        description: Anthropic API key
+---
+
+# Claude Code
+
+Agent instructions...
+```
+
+### Agent frontmatter fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Package slug (lowercase, URL-safe) |
+| `description` | Yes | One-line summary |
+| `version` | No | Semver version (auto-incremented if omitted) |
+| `metadata.strawpot.bin` | No | OS-specific binary names |
+| `metadata.strawpot.tools` | No | System tool requirements |
+| `metadata.strawpot.params` | No | Configurable parameters |
+| `metadata.strawpot.env` | No | Required environment variables |
+
+### Agent file constraints
+
+- Up to 50 files, 10 MB each, 50 MB total
+- Supports binary files (compiled executables)
+
+## Memories
+
+A memory is a persistent knowledge bank that stores context and patterns across agent sessions:
+
+- **Required:** `MEMORY.md` — YAML frontmatter + markdown body
+- **Optional:** supporting files (data, indexes, binary assets)
+
+### MEMORY.md
+
+```yaml
+---
+name: project-context
+description: "Persistent project context and conventions"
+---
+
+# Project Context
+
+Memory contents for the agent...
+```
+
+### Memory frontmatter fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Package slug (lowercase, URL-safe) |
+| `description` | Yes | One-line summary |
+| `version` | No | Semver version (auto-incremented if omitted) |
+
+### Memory file constraints
+
+- Up to 50 files, 10 MB each, 50 MB total
+- Supports binary files
+
 ## System Tools
 
 Skills can declare system tool requirements under `metadata.strawpot.tools`:
@@ -117,10 +208,15 @@ During `strawhub install` / `strawhub update`, the CLI checks if each declared t
 
 ## File Constraints
 
+### Skills and Roles
 - Up to 20 files per package, 512 KB each
 - Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 - Roles must contain exactly one file named `ROLE.md`
 
+### Agents and Memories
+- Up to 50 files per package, 10 MB each, 50 MB total
+- Supports binary files (compiled executables, data files)
+
 ## Naming
 
-Slugs must be lowercase and URL-safe. Slug uniqueness is per-type — skills and roles have separate namespaces.
+Slugs must be lowercase and URL-safe. Slug uniqueness is per-type — skills, roles, agents, and memories each have separate namespaces.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -111,7 +111,7 @@ Additional constraints:
 
 ## Search
 
-### Search Skills and Roles
+### Search Skills, Roles, Agents, and Memories
 
 ```
 GET /api/v1/search?q=review&kind=all&limit=20
@@ -119,7 +119,7 @@ GET /api/v1/search?q=review&kind=all&limit=20
 
 Query params:
 - `q` (required) — search query
-- `kind` (`all` | `skill` | `role`, default `all`)
+- `kind` (`all` | `skill` | `role` | `agent` | `memory`, default `all`)
 - `limit` (1-100, default 20)
 
 Uses hybrid ranking: vector similarity + lexical matching + popularity boost.
@@ -196,6 +196,110 @@ Soft-deletes a role. Requires moderator or admin role.
 
 ---
 
+## Agents
+
+### List Agents
+
+```
+GET /api/v1/agents?limit=50&sort=updated
+```
+
+Query params:
+- `limit` (1-200, default 50)
+- `sort` (`updated` | `downloads` | `stars`)
+
+Response shape matches List Skills.
+
+### Publish Agent (auth required)
+
+```
+POST /api/v1/agents
+Content-Type: multipart/form-data
+
+payload: { slug, displayName, version, changelog, customTags?, files[] }
+```
+
+File constraints: up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+
+### Get Agent Detail
+
+```
+GET /api/v1/agents/:slug
+```
+
+Returns full detail for a single agent (public).
+
+### Get Agent File
+
+```
+GET /api/v1/agents/:slug/file?path=AGENT.md
+```
+
+Returns the raw file content for an agent. `path` defaults to `AGENT.md`.
+
+### Delete Agent (auth required)
+
+```
+DELETE /api/v1/agents/:slug
+Authorization: Bearer sh_xxxxx
+```
+
+Soft-deletes an agent. Requires moderator or admin role.
+
+---
+
+## Memories
+
+### List Memories
+
+```
+GET /api/v1/memories?limit=50&sort=updated
+```
+
+Query params:
+- `limit` (1-200, default 50)
+- `sort` (`updated` | `downloads` | `stars`)
+
+Response shape matches List Skills.
+
+### Publish Memory (auth required)
+
+```
+POST /api/v1/memories
+Content-Type: multipart/form-data
+
+payload: { slug, displayName, version, changelog, customTags?, files[] }
+```
+
+File constraints: up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+
+### Get Memory Detail
+
+```
+GET /api/v1/memories/:slug
+```
+
+Returns full detail for a single memory (public).
+
+### Get Memory File
+
+```
+GET /api/v1/memories/:slug/file?path=MEMORY.md
+```
+
+Returns the raw file content for a memory. `path` defaults to `MEMORY.md`.
+
+### Delete Memory (auth required)
+
+```
+DELETE /api/v1/memories/:slug
+Authorization: Bearer sh_xxxxx
+```
+
+Soft-deletes a memory. Requires moderator or admin role.
+
+---
+
 ## Stars
 
 ### Toggle Star (auth required)
@@ -205,7 +309,7 @@ POST /api/v1/stars/toggle
 Authorization: Bearer sh_xxxxx
 Content-Type: application/json
 
-{ "slug": "git-workflow", "kind": "skill" }
+{ "slug": "git-workflow", "kind": "skill|role|agent|memory" }
 ```
 
 Toggles the star status for the authenticated user. Returns `{ "starred": true }` or `{ "starred": false }`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -129,7 +129,55 @@ Publish:
 strawhub publish role . --version 1.0.0 --changelog "Initial release"
 ```
 
-## 7) Project file
+## 7) Publish an agent
+
+Create a directory with an `AGENT.md`:
+
+```bash
+mkdir my-agent && cd my-agent
+cat > AGENT.md <<'EOF'
+---
+name: my-agent
+description: "A demo agent"
+---
+
+# My Agent
+
+Agent instructions.
+EOF
+```
+
+Publish:
+
+```bash
+strawhub publish agent . --version 1.0.0 --changelog "Initial release"
+```
+
+## 8) Publish a memory
+
+Create a directory with a `MEMORY.md`:
+
+```bash
+mkdir my-memory && cd my-memory
+cat > MEMORY.md <<'EOF'
+---
+name: my-memory
+description: "A demo memory"
+---
+
+# My Memory
+
+Persistent context for the agent.
+EOF
+```
+
+Publish:
+
+```bash
+strawhub publish memory . --version 1.0.0 --changelog "Initial release"
+```
+
+## 9) Project file
 
 Declare dependencies in `strawpot.toml` for reproducible installs:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,20 +10,20 @@
 
 ## Content ownership
 
-- Only the **owner** can publish new versions of an existing skill or role
+- Only the **owner** can publish new versions of an existing skill, role, agent, or memory
 - Users **cannot** delete their own content — only admins can soft-delete
-- Slug ownership is per-type: skills and roles have separate namespaces
+- Slug ownership is per-type: skills, roles, agents, and memories each have separate namespaces
 
 ## Reporting
 
-Users can report skills, roles, and comments for moderation review.
+Users can report skills, roles, agents, memories, and comments for moderation review.
 
 ## Moderation
 
 Public queries exclude soft-deleted content. Admin queries retain access to deleted items for review and restoration.
 
 Admins can:
-- Soft-delete and restore skills and roles
+- Soft-delete and restore skills, roles, agents, and memories
 - Ban and unban users
 - Assign user roles (admin, moderator, user)
 
@@ -65,8 +65,15 @@ All rate limits are per IP address.
 
 ## Upload constraints
 
+### Skills and Roles
 - Max 20 files per package, 512 KB each
 - Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 - Roles must contain exactly one file (`ROLE.md`)
+
+### Agents and Memories
+- Max 50 files per package, 10 MB each, 50 MB total
+- Supports binary files (compiled executables, data files)
+
+### All types
 - Version monotonicity: new versions must be strictly greater than the latest
 - Dependency constraints are validated at publish time

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-StrawHub is a web registry for StrawPot roles and skills. Users discover, publish, and install reusable agent components through a web UI or REST API.
+StrawHub is a web registry for StrawPot roles, skills, agents, and memories. Users discover, publish, and install reusable agent components through a web UI or REST API.
 
 ## Content Types
 
@@ -93,6 +93,22 @@ metadata:
         description: Anthropic API key
 ```
 
+### Memories
+
+A memory is a persistent knowledge bank that stores context, patterns, and learned information across agent sessions.
+
+**Files:**
+- `MEMORY.md` (required) — YAML frontmatter + markdown body
+- Supporting files (optional) — data, indexes, binary assets
+
+**Frontmatter:**
+```yaml
+name: project-context
+description: "Persistent project context and conventions"
+```
+
+**File constraints:** Up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+
 ## Dependencies
 
 Dependencies are declared under `metadata.strawpot.dependencies`. Skills use a flat list of slugs (skills can only depend on other skills). Roles use a structured object with `skills` and `roles` sub-keys. The `roles` list supports `"*"` as a wildcard meaning "all available roles" — this is expanded at runtime by StrawPot and filtered out during install.
@@ -181,9 +197,13 @@ The resolution logic exists server-side (handler in `rolesV1.ts`) but is not yet
 | `/skills/$slug` | Skill detail — file viewer with frontmatter table, version history, zip download, owner update button |
 | `/roles` | Browse roles |
 | `/roles/$slug` | Role detail — file viewer, version history, zip download |
-| `/search` | Search skills, roles, and agents |
+| `/agents` | Browse agents |
+| `/agents/$slug` | Agent detail — file viewer, version history, zip download |
+| `/memories` | Browse memories |
+| `/memories/$slug` | Memory detail — file viewer, version history, zip download |
+| `/search` | Search skills, roles, agents, and memories |
 | `/upload` | Publish — drag-and-drop files or folders, GitHub import, form auto-fill from frontmatter, update mode via `?updateSlug=` |
-| `/dashboard` | My content — manage published skills, roles, and agents |
+| `/dashboard` | My content — manage published skills, roles, agents, and memories |
 | `/settings` | Profile editing, API tokens, account deletion |
 
 ### Authentication
@@ -195,13 +215,13 @@ The resolution logic exists server-side (handler in `rolesV1.ts`) but is not yet
 ### Publishing
 
 - **Web UI**: Drag-and-drop files or use the GitHub import (paste a URL, files are fetched via GitHub Contents API)
-- SKILL.md / ROLE.md frontmatter is auto-parsed to populate form fields (slug, display name)
+- SKILL.md / ROLE.md / AGENT.md / MEMORY.md frontmatter is auto-parsed to populate form fields (slug, display name)
 - Slug ownership: if a slug already exists and belongs to another user, publishing is blocked
-- Slug uniqueness is per-type: skills and roles have separate slug namespaces
+- Slug uniqueness is per-type: skills, roles, agents, and memories each have separate slug namespaces
 - Version monotonicity: new versions must be strictly greater than the latest published version; auto-incremented patch if omitted
 - Dependency validation errors are aggregated — all issues are reported together rather than failing on the first one
 - Zip archives nest files under `{slug}-{version}/` so they extract into a named directory
-- **REST API**: `POST /api/v1/skills` and `POST /api/v1/roles` with bearer token auth (multipart form data)
+- **REST API**: `POST /api/v1/skills`, `POST /api/v1/roles`, `POST /api/v1/agents`, and `POST /api/v1/memories` with bearer token auth (multipart form data)
 
 ### API Tokens
 
@@ -214,13 +234,13 @@ The resolution logic exists server-side (handler in `rolesV1.ts`) but is not yet
 
 | Action | Who |
 |--------|-----|
-| Publish new skill/role | Any authenticated user |
-| Update existing skill/role | Owner only |
-| Delete (soft-delete) skill/role | Admin only |
-| Restore skill/role | Admin only |
+| Publish new skill/role/agent/memory | Any authenticated user |
+| Update existing skill/role/agent/memory | Owner only |
+| Delete (soft-delete) skill/role/agent/memory | Admin only |
+| Restore skill/role/agent/memory | Admin only |
 | Delete own account | Authenticated user (self) |
 
-Users cannot delete their own published skills or roles. Only administrators can remove content from the registry.
+Users cannot delete their own published content. Only administrators can remove content from the registry.
 
 ### Admin Assignment
 
@@ -235,8 +255,14 @@ Admins are designated via the `ADMIN_GITHUB_LOGINS` Convex environment variable 
 - `roles` — role registry entries (parallel to skills)
 - `roleVersions` — versioned role bundles with skill/role dependency declarations
 - `roleEmbeddings` — vector embeddings for search
-- `stars` — user stars on skills/roles
-- `comments` — user comments on skills/roles
+- `agents` — agent registry entries with stats, badges, moderation status
+- `agentVersions` — versioned agent bundles (files in Convex storage, supports binary files)
+- `agentEmbeddings` — vector embeddings for search
+- `memories` — memory registry entries with stats, badges, moderation status
+- `memoryVersions` — versioned memory bundles (files in Convex storage, supports binary files)
+- `memoryEmbeddings` — vector embeddings for search
+- `stars` — user stars on skills/roles/agents/memories
+- `comments` — user comments on skills/roles/agents/memories
 - `apiTokens` — SHA-256 hashed bearer tokens for CLI/API auth
 - `auditLogs` — moderation action trail
 - `rateLimits` — per-IP/per-token rate limiting


### PR DESCRIPTION
## Summary
- Update all 10 documentation files to include agents and memories alongside skills and roles
- Add Memories content type section to spec, content-format, HTTP API, and quickstart
- Update CLI reference with memory subcommands for search, info, list, publish, star, delete
- Update security docs with per-type upload constraints for agents/memories (50 files, 10MB)

## Test plan
- [ ] Review rendered markdown for all updated docs
- [ ] Verify no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)