### PR TITLE
Add memory comparison row to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Discover, publish, and install **roles**, **skills**, **agents**, and **memories
 | **Format** | YAML + Python | JSON5 + Markdown | Markdown only |
 | **Skills / Tools** | Python (tools) | Markdown (skills) | Markdown (skills) |
 | **Roles** | Agent attribute | — | Standalone Markdown |
+| **Memory** | Python config | Markdown/YAML (local) | Markdown (installable) |
 | **Skill dependency resolution** | — | — | Automatic |
 | **Multi-agent delegation** | Python config | Runtime (subagent spawn) | Declarative (role deps) |
 


### PR DESCRIPTION
## Summary
- Adds a **Memory** row to the comparison table highlighting that StrawPot memories are installable packages from the registry, vs CrewAI's Python config and OpenClaw's local-only Markdown/YAML files.

## Test plan
- [ ] Verify the table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)