### PR TITLE
Rewrite README for maximum virality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,120 @@
 # StrawHub
 
+npm for AI agents.
+
+Browse, install, and publish the roles, skills, agents, and memories that power your AI workforce.
+
 <p align="center">
   <a href="https://github.com/strawpot/strawhub/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/strawpot/strawhub/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
   <a href="https://discord.gg/buEbvEMC"><img src="https://img.shields.io/discord/1476285531464929505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-StrawHub is the registry for [StrawPot](https://strawpot.com) — the open-source framework for role-based AI agents.
+```
+strawhub install role ai-ceo
 
-Discover, publish, and install **roles**, **skills**, **agents**, and **memories** that power StrawPot.
+  Resolving dependencies...
+
+  ✓ skill  git-workflow
+  ✓ skill  python-dev
+  ✓ skill  code-review
+  ✓ skill  security-baseline
+  ✓ role   pm
+  ✓ role   implementer
+  ✓ role   reviewer
+  ✓ role   ai-ceo
+
+  8 packages installed.
+```
+
+One command. Your entire AI company — skills, roles, and all their dependencies — ready to work.
+
+## The Problem
+
+AI agents are powerful. But every team reinvents the wheel:
+
+- Write the same "code review" prompt for the tenth time
+- Copy-paste skills between projects
+- No way to share what works
+
+**StrawHub is a package registry for AI agent capabilities.** Publish once, install anywhere.
+
+## Quick Start
+
+```bash
+pip install strawpot        # the runtime
+pip install strawhub        # the registry CLI
+
+strawhub install role ai-ceo
+strawpot start
+```
+
+That's it. StrawHub resolves every skill and sub-role your AI CEO needs. StrawPot runs them.
+
+## What's Inside
 
 ```
-# CrewAI: 40 lines of Python to define a 2-agent team
-# OpenClaw: Skills in Markdown, but no roles or dependency resolution
-# StrawPot: One ROLE.md file. Done.
+┌─────────────────────────────────────────────┐
+│                  StrawHub                    │
+│                                             │
+│   Skills          Roles          Memories   │
+│  ┌──────────┐   ┌──────────┐   ┌─────────┐ │
+│  │git-wflow │   │ai-ceo    │   │proj-ctx  │ │
+│  │code-rev  │   │pm        │   │patterns  │ │
+│  │py-test   │   │implmtr   │   │decisions │ │
+│  │debugging │   │reviewer  │   │lessons   │ │
+│  └──────────┘   └──────────┘   └─────────┘ │
+│                                             │
+│   Agents                                    │
+│  ┌──────────────────────────────┐           │
+│  │claude_code · codex · gemini  │           │
+│  └──────────────────────────────┘           │
+└─────────────────────────────────────────────┘
 ```
 
-| | CrewAI | OpenClaw | StrawPot |
+### Skills — what agents can do
+Atomic capabilities: writing code, reviewing PRs, running tests, searching docs.
+
+### Roles — what agents are
+Job definitions that bundle skills. An `ai-ceo` depends on `pm`, `implementer`, and `reviewer` — StrawPot handles the delegation.
+
+### Memories — what agents remember
+Persistent knowledge banks: project context, code patterns, past decisions. Install shared context from StrawHub so new agents start smart.
+
+### Agents — where agents run
+Runtime wrappers for Claude Code, Codex, Gemini, or your own CLI.
+
+## Everything Is a Markdown File
+
+```yaml
+# ai-ceo/ROLE.md
+---
+name: ai-ceo
+description: "Plans strategy and delegates to the team"
+metadata:
+  strawpot:
+    dependencies:
+      roles: [pm, implementer, reviewer]
+    default_agent: claude_code
+---
+
+# CEO
+
+Plan strategy and break it into deliverables.
+Delegate planning, implementation, and review to sub-roles.
+```
+
+No Python. No YAML config files. No orchestration code. **One Markdown file per role.**
+
+## How It Compares
+
+```
+# CrewAI:    40 lines of Python to define a 2-agent team
+# OpenClaw:  Skills in Markdown, but no roles or dependency resolution
+# StrawPot:  One ROLE.md file. Done.
+```
+
+| | CrewAI | OpenClaw | StrawPot + StrawHub |
 |---|---|---|---|
 | **Format** | YAML + Python | JSON5 + Markdown | Markdown only |
 | **Skills / Tools** | Python (tools) | Markdown (skills) | Markdown (skills) |
@@ -24,127 +122,72 @@ Discover, publish, and install **roles**, **skills**, **agents**, and **memories
 | **Memory** | Python config | Markdown/YAML (local) | Markdown (installable) |
 | **Skill dependency resolution** | — | — | Automatic |
 | **Multi-agent delegation** | Python config | Runtime (subagent spawn) | Declarative (role deps) |
+| **Package registry** | — | — | **StrawHub** |
 
-## Why StrawPot?
+## Automatic Dependency Resolution
 
-Define your AI team in Markdown. No Python. No orchestration code. Push a ROLE.md, install it, and your agents know what to do.
+Install a role. Everything it needs comes with it.
 
-- **Zero boilerplate** — A role is a Markdown file with YAML frontmatter. That's it.
-- **Automatic dependency resolution** — Install a role and every skill it needs comes with it.
-- **Declarative delegation** — A team-lead role depends on other roles. StrawPot handles the orchestration.
-- **Agent-agnostic** — Same role works with Claude Code, Codex, Gemini, or your own runtime.
+```
+strawhub install role ai-ceo
 
-## Quick Start
-
-```bash
-pip install strawpot        # the runtime
-pip install strawhub        # the registry CLI
-strawhub install role implementer
+  ai-ceo
+  ├─ role: pm
+  │   ├─ skill: project-planning
+  │   └─ skill: task-breakdown
+  ├─ role: implementer
+  │   ├─ skill: git-workflow
+  │   ├─ skill: python-dev
+  │   ├─ skill: run-tests
+  │   └─ skill: code-review
+  └─ role: reviewer
+      ├─ skill: code-review       (already installed)
+      └─ skill: security-baseline
 ```
 
-StrawHub resolves all required skills automatically.
+Skills use client-side DFS. Roles use server-side topological sort with cycle detection. You don't have to think about any of it.
 
-## StrawPot Ecosystem
+## CLI
 
-| Project | Role |
-|---------|------|
+```bash
+# Install
+strawhub install role ai-ceo
+strawhub install skill git-workflow
+strawhub install memory project-context
+
+# Discover
+strawhub search "code review"
+strawhub info role ai-ceo
+strawhub list
+
+# Publish
+strawhub publish role ./my-role/
+strawhub publish skill ./my-skill/
+
+# Manage
+strawhub login
+strawhub whoami
+```
+
+## Ecosystem
+
+| Project | What it does |
+|---------|-------------|
 | [**StrawPot**](https://strawpot.com) | Runtime — runs role-based AI agents locally |
-| [**StrawHub**](https://strawhub.dev) | Registry — distributes roles, skills, and agents |
+| [**StrawHub**](https://strawhub.dev) | Registry — distributes roles, skills, agents, and memories |
 | [**Denden**](https://github.com/strawpot/denden) | Transport — gRPC bridge between agents and the orchestrator |
 
 ```
- User task → StrawPot runtime → Role (team-lead)
-                                  ├─ Sub-role (implementer)
-                                  │   ├─ Skills (git-workflow, python-dev)
-                                  │   └─ Agent (claude_code)
-                                  └─ Sub-role (reviewer)
-                                      ├─ Skills (code-review, security-baseline)
-                                      └─ Agent (claude_code)
+User task → StrawPot runtime → Role (ai-ceo)
+                                 ├─ Sub-role (pm)
+                                 │   └─ Skills (project-planning, task-breakdown)
+                                 ├─ Sub-role (implementer)
+                                 │   ├─ Skills (git-workflow, python-dev)
+                                 │   └─ Agent (claude_code)
+                                 └─ Sub-role (reviewer)
+                                     ├─ Skills (code-review, security-baseline)
+                                     └─ Agent (gemini)
 ```
-
-## Concepts
-
-Skills are abilities. Roles are jobs. A team-lead role delegates to other roles as sub-agents.
-
-### Skill
-Atomic capabilities such as writing code, searching documents, or running tests.
-
-Examples: `git-workflow` · `code-review` · `debugging` · `web-search`
-
-### Role
-Job definitions that bundle the skills needed for the work. A role like `team-lead` can depend on other roles and delegate tasks to them as sub-agents.
-
-Examples: `implementer` · `reviewer` · `analyst` · `team-lead`
-
-### Agent
-CLI runtimes that execute roles. Each agent bridges StrawPot to a specific AI platform like Claude Code, ChatGPT, or Gemini.
-
-Examples: `claude_code` · `codex` · `gemini`
-
-### Memory
-Persistent memory banks that store knowledge, context, and learned patterns across agent sessions.
-
-Examples: `project-context` · `code-patterns` · `team-decisions`
-
-### Dependencies
-Roles and skills declare dependencies under `metadata.strawpot.dependencies`. A role can depend on skills (capabilities it needs) and other roles (sub-agents it delegates to). Dependencies are resolved automatically on install.
-
-## Content Formats
-
-### ROLE.md
-
-```yaml
----
-name: implementer
-description: "Writes code to implement features and fix bugs"
-metadata:
-  strawpot:
-    dependencies:
-      skills:
-        - git-workflow
-        - code-review
-        - python-testing
-      roles:
-        - reviewer
-    default_agent: claude_code
----
-
-# Implementer
-
-Role instructions for the agent...
-```
-
-### SKILL.md
-
-```yaml
----
-name: code-review
-description: "Code review checklist and structured review output"
-metadata:
-  strawpot:
-    dependencies:
-      - security-baseline
-      - git-workflow
-    tools:
-      gh:
-        description: GitHub CLI
-        install:
-          macos: brew install gh
-          linux: apt install gh
-          windows: winget install GitHub.cli
----
-
-# Code Review
-
-Instructions for the agent...
-```
-
-## Roadmap
-
-- [x] Skills registry
-- [x] Roles registry
-- [x] Agents registry
-- [x] Memories registry
 
 ## Documentation
 
@@ -157,3 +200,11 @@ Instructions for the agent...
 ## License
 
 [MIT](LICENSE)
+
+---
+
+<p align="center">
+Great engineers shouldn't re-invent agent skills.<br>
+They should install them.<br>
+<strong><a href="https://strawhub.dev">strawhub.dev</a></strong>
+</p>


### PR DESCRIPTION
## Summary
- Restructure README with storytelling arc (problem → solution → how it works) inspired by strawpot.com
- Add "npm for AI agents" tagline, hero install output, problem framing, ASCII visualizations
- Update all examples to use `ai-ceo` role matching StrawPot README
- Add comparison table row for package registry and vision closing statement

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all examples match StrawPot README (`ai-ceo` with `[pm, implementer, reviewer]`)
- [ ] Check ASCII art alignment in GitHub markdown renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)