### PR TITLE
Proxy /api/v1 requests to Convex via Vercel rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
   "rewrites": [
-{ "source": "/(.*)", "destination": "/" }
+    {
+      "source": "/api/v1/:path*",
+      "destination": "https://wry-manatee-359.convex.site/api/v1/:path*"
+    },
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Vercel rewrite rule to proxy `/api/v1/*` requests to the Convex site URL (`wry-manatee-359.convex.site`)
- Fixes `strawpot start` failing with "Server returned HTML instead of JSON" when the CLI uses the default `https://strawhub.dev` API base URL
- The rewrite is placed before the SPA catch-all so API paths aren't swallowed by the frontend

## Test plan
- [ ] Deploy to Vercel preview and verify `curl https://<preview-url>/api/v1/agents` returns JSON
- [ ] Run `strawpot start` without `STRAWHUB_API_URL` set and confirm agent installation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)