### PR TITLE
Use slug-only directories for installed packages

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -16,6 +16,7 @@ from strawhub.paths import (
     get_project_file_path,
     find_installed_versions,
     package_exists,
+    get_installed_version,
 )
 from strawhub.project_file import ProjectFile
 from strawhub.tools import run_tool_installs_for_package
@@ -143,7 +144,7 @@ def _install_impl(
                             f"'{slug}' v{found_version} is already installed ({scope})."
                         )
                         # Register as direct install if in our scope
-                        if package_exists(root, kind, slug, found_version):
+                        if package_exists(root, kind, slug):
                             existing_ref = PackageRef(
                                 kind=kind, slug=slug, version=found_version
                             )
@@ -193,9 +194,7 @@ def _install_impl(
                             slug=dep_slug,
                             version=existing_dep_in_scope,
                         )
-                        if package_exists(
-                            root, dep_kind, dep_slug, existing_dep_in_scope
-                        ):
+                        if package_exists(root, dep_kind, dep_slug):
                             lockfile.add_package(dep_ref, dependent=root_ref)
                         installed_deps.append(
                             {
@@ -211,7 +210,7 @@ def _install_impl(
                 elif existing_dep_anywhere:
                     # Skip: already installed in some scope
                     _, dep_ver = existing_dep_anywhere
-                    if package_exists(root, dep_kind, dep_slug, dep_ver):
+                    if package_exists(root, dep_kind, dep_slug):
                         dep_ref = PackageRef(
                             kind=dep_kind, slug=dep_slug, version=dep_ver
                         )
@@ -250,9 +249,7 @@ def _install_impl(
                 pkg = lockfile.packages.get(key)
                 if not pkg:
                     continue
-                pkg_dir = get_package_dir(
-                    root, pkg["kind"], pkg["slug"], pkg["version"]
-                )
+                pkg_dir = get_package_dir(root, pkg["kind"], pkg["slug"])
                 if pkg_dir.is_dir():
                     shutil.rmtree(pkg_dir)
                 lockfile.remove_package(key)
@@ -717,7 +714,7 @@ def _remove_from_scope(
     version = _slug_installed_in_scope(root, kind, slug)
     if not version:
         return None
-    pkg_dir = get_package_dir(root, kind, slug, version)
+    pkg_dir = get_package_dir(root, kind, slug)
     if pkg_dir.is_dir():
         shutil.rmtree(pkg_dir)
     ref = PackageRef(kind=kind, slug=slug, version=version)
@@ -737,12 +734,12 @@ def _download_package(
     root: Path,
     version: str | None = None,
 ) -> None:
-    """Download a package's files into root/{kind}s/{slug}-{version}/.
+    """Download a package's files into root/{kind}s/{slug}/.
 
     When *version* is given, it is passed to the API to request a specific
     version.  Otherwise the latest version files are fetched.
     """
-    target_dir = get_package_dir(root, kind, slug, target_version)
+    target_dir = get_package_dir(root, kind, slug)
     target_dir.mkdir(parents=True, exist_ok=True)
 
     # Fetch detail to get file list
@@ -766,6 +763,9 @@ def _download_package(
         else:
             content = client.get_role_file(slug, path=file_path, version=version)
             out_file.write_text(content, encoding="utf-8")
+
+    # Write version marker for local version lookups
+    (target_dir / ".version").write_text(target_version + "\n", encoding="utf-8")
 
 
 # ── Project file install ─────────────────────────────────────────────────────

--- a/cli/src/strawhub/commands/uninstall.py
+++ b/cli/src/strawhub/commands/uninstall.py
@@ -54,7 +54,7 @@ def _uninstall_impl(slug, kind, ver, is_global, save=False):
         pkg = lockfile.packages.get(key)
         if not pkg:
             continue
-        pkg_dir = get_package_dir(root, pkg["kind"], pkg["slug"], pkg["version"])
+        pkg_dir = get_package_dir(root, pkg["kind"], pkg["slug"])
         if pkg_dir.is_dir():
             shutil.rmtree(pkg_dir)
         lockfile.remove_package(key)

--- a/cli/src/strawhub/lockfile.py
+++ b/cli/src/strawhub/lockfile.py
@@ -36,8 +36,8 @@ class PackageRef:
 
     @property
     def dir_name(self) -> str:
-        """Directory name, e.g. 'git-workflow-1.0.0'."""
-        return f"{self.slug}-{self.version}"
+        """Directory name (same as slug)."""
+        return self.slug
 
 
 class Lockfile:

--- a/cli/src/strawhub/paths.py
+++ b/cli/src/strawhub/paths.py
@@ -7,7 +7,13 @@ Local root:  ./.strawpot in the current working directory
 import os
 from pathlib import Path
 
-from strawhub.version_spec import parse_dir_name
+
+_KIND_SUBDIRS = {
+    "skill": "skills",
+    "role": "roles",
+    "agent": "agents",
+    "memory": "memories",
+}
 
 
 def get_project_file_path() -> Path:
@@ -48,32 +54,25 @@ def get_lockfile_path(root: Path) -> Path:
     return root / "strawpot.lock"
 
 
-def get_package_dir(root: Path, kind: str, slug: str, version: str) -> Path:
-    """Return the package directory path, e.g. root/skills/git-workflow-1.0.0/"""
-    subdir = {"skill": "skills", "role": "roles", "agent": "agents", "memory": "memories"}[kind]
-    return root / subdir / f"{slug}-{version}"
+def get_package_dir(root: Path, kind: str, slug: str) -> Path:
+    """Return the package directory path, e.g. root/skills/git-workflow/"""
+    return root / _KIND_SUBDIRS[kind] / slug
 
 
-def package_exists(root: Path, kind: str, slug: str, version: str) -> bool:
+def package_exists(root: Path, kind: str, slug: str) -> bool:
     """Check if a package directory exists."""
-    return get_package_dir(root, kind, slug, version).is_dir()
+    return get_package_dir(root, kind, slug).is_dir()
+
+
+def get_installed_version(root: Path, kind: str, slug: str) -> str | None:
+    """Read the installed version from the .version file in a package dir."""
+    version_file = get_package_dir(root, kind, slug) / ".version"
+    if version_file.is_file():
+        return version_file.read_text(encoding="utf-8").strip()
+    return None
 
 
 def find_installed_versions(root: Path, kind: str, slug: str) -> list[str]:
-    """Scan .strawpot/{kind}s/ for directories matching {slug}-X.Y.Z.
-
-    Returns a list of version strings found on disk.
-    """
-    subdir = {"skill": "skills", "role": "roles", "agent": "agents", "memory": "memories"}[kind]
-    parent = root / subdir
-    if not parent.is_dir():
-        return []
-
-    versions = []
-    for entry in parent.iterdir():
-        if not entry.is_dir():
-            continue
-        parsed = parse_dir_name(entry.name)
-        if parsed and parsed[0] == slug:
-            versions.append(parsed[1])
-    return versions
+    """Return the installed version of a slug as a list (empty or single-element)."""
+    version = get_installed_version(root, kind, slug)
+    return [version] if version else []

--- a/cli/src/strawhub/resolver.py
+++ b/cli/src/strawhub/resolver.py
@@ -14,13 +14,13 @@ from strawhub.errors import DependencyError
 from strawhub.frontmatter import parse_frontmatter, extract_dependencies
 from strawhub.paths import (
     get_global_root,
+    get_installed_version,
     get_local_root,
     get_package_dir,
 )
 from strawhub.version_spec import (
     DependencySpec,
     extract_slug,
-    parse_dir_name,
     parse_version,
     satisfies_version,
 )
@@ -185,10 +185,10 @@ def _build_index(
             for entry in subdir.iterdir():
                 if not entry.is_dir():
                     continue
-                parsed = parse_dir_name(entry.name)
-                if not parsed:
+                pkg_slug = entry.name
+                pkg_version = get_installed_version(root, kind, pkg_slug)
+                if not pkg_version:
                     continue
-                pkg_slug, pkg_version = parsed
                 key = (kind, pkg_slug)
                 if key not in index:
                     index[key] = []

--- a/cli/src/strawhub/tools.py
+++ b/cli/src/strawhub/tools.py
@@ -157,7 +157,7 @@ def run_tool_installs_for_package(
     seen: set[str] | None = None,
 ) -> list[dict]:
     """Extract tools from a downloaded package and run installs."""
-    pkg_dir = get_package_dir(root, kind, slug, version)
+    pkg_dir = get_package_dir(root, kind, slug)
     main_file = "SKILL.md" if kind == "skill" else "ROLE.md"
     md_path = pkg_dir / main_file
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -27,7 +27,7 @@ def make_skill(strawpot_dir):
     """Factory fixture to create a skill directory with SKILL.md."""
 
     def _make(slug, version, deps=None):
-        d = strawpot_dir / "skills" / f"{slug}-{version}"
+        d = strawpot_dir / "skills" / slug
         d.mkdir(parents=True, exist_ok=True)
 
         dep_section = ""
@@ -43,6 +43,7 @@ def make_skill(strawpot_dir):
         (d / "SKILL.md").write_text(
             f"---\nname: {slug}\ndescription: \"{slug} skill\"\n{dep_section}---\n\n# {slug}\n"
         )
+        (d / ".version").write_text(version + "\n")
         return d
 
     return _make
@@ -53,7 +54,7 @@ def make_role(strawpot_dir):
     """Factory fixture to create a role directory with ROLE.md."""
 
     def _make(slug, version, skill_deps=None, role_deps=None):
-        d = strawpot_dir / "roles" / f"{slug}-{version}"
+        d = strawpot_dir / "roles" / slug
         d.mkdir(parents=True, exist_ok=True)
 
         dep_section = ""
@@ -76,6 +77,7 @@ def make_role(strawpot_dir):
         (d / "ROLE.md").write_text(
             f"---\nname: {slug}\ndescription: \"{slug} role\"\n{dep_section}---\n\n# {slug}\n"
         )
+        (d / ".version").write_text(version + "\n")
         return d
 
     return _make

--- a/cli/tests/test_lockfile.py
+++ b/cli/tests/test_lockfile.py
@@ -14,7 +14,7 @@ class TestPackageRef:
 
     def test_dir_name(self):
         ref = PackageRef("role", "implementer", "2.1.0")
-        assert ref.dir_name == "implementer-2.1.0"
+        assert ref.dir_name == "implementer"
 
     def test_frozen(self):
         ref = PackageRef("skill", "git-workflow", "1.0.0")

--- a/cli/tests/test_paths.py
+++ b/cli/tests/test_paths.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from strawhub.paths import (
     find_installed_versions,
     get_global_root,
+    get_installed_version,
     get_lockfile_path,
     get_package_dir,
     package_exists,
@@ -24,12 +25,12 @@ class TestGetGlobalRoot:
 
 class TestGetPackageDir:
     def test_skill(self, tmp_path):
-        result = get_package_dir(tmp_path, "skill", "git-workflow", "1.0.0")
-        assert result == tmp_path / "skills" / "git-workflow-1.0.0"
+        result = get_package_dir(tmp_path, "skill", "git-workflow")
+        assert result == tmp_path / "skills" / "git-workflow"
 
     def test_role(self, tmp_path):
-        result = get_package_dir(tmp_path, "role", "implementer", "2.1.0")
-        assert result == tmp_path / "roles" / "implementer-2.1.0"
+        result = get_package_dir(tmp_path, "role", "implementer")
+        assert result == tmp_path / "roles" / "implementer"
 
 
 class TestGetLockfilePath:
@@ -39,26 +40,46 @@ class TestGetLockfilePath:
 
 class TestPackageExists:
     def test_exists(self, tmp_path):
-        d = tmp_path / "skills" / "git-workflow-1.0.0"
+        d = tmp_path / "skills" / "git-workflow"
         d.mkdir(parents=True)
-        assert package_exists(tmp_path, "skill", "git-workflow", "1.0.0") is True
+        assert package_exists(tmp_path, "skill", "git-workflow") is True
 
     def test_not_exists(self, tmp_path):
-        assert package_exists(tmp_path, "skill", "git-workflow", "1.0.0") is False
+        assert package_exists(tmp_path, "skill", "git-workflow") is False
+
+
+class TestGetInstalledVersion:
+    def test_has_version(self, tmp_path):
+        pkg = tmp_path / "skills" / "git-workflow"
+        pkg.mkdir(parents=True)
+        (pkg / ".version").write_text("1.2.3\n")
+        assert get_installed_version(tmp_path, "skill", "git-workflow") == "1.2.3"
+
+    def test_no_version_file(self, tmp_path):
+        pkg = tmp_path / "skills" / "git-workflow"
+        pkg.mkdir(parents=True)
+        assert get_installed_version(tmp_path, "skill", "git-workflow") is None
+
+    def test_no_dir(self, tmp_path):
+        assert get_installed_version(tmp_path, "skill", "git-workflow") is None
 
 
 class TestFindInstalledVersions:
-    def test_multiple_versions(self, tmp_path):
-        skills = tmp_path / "skills"
-        (skills / "git-workflow-1.0.0").mkdir(parents=True)
-        (skills / "git-workflow-1.4.0").mkdir(parents=True)
-        (skills / "git-workflow-2.0.0").mkdir(parents=True)
-        (skills / "other-skill-1.0.0").mkdir(parents=True)
+    def test_installed(self, tmp_path):
+        pkg = tmp_path / "skills" / "git-workflow"
+        pkg.mkdir(parents=True)
+        (pkg / ".version").write_text("2.0.0\n")
 
         versions = find_installed_versions(tmp_path, "skill", "git-workflow")
-        assert sorted(versions) == ["1.0.0", "1.4.0", "2.0.0"]
+        assert versions == ["2.0.0"]
 
-    def test_no_versions(self, tmp_path):
+    def test_no_version_file(self, tmp_path):
+        pkg = tmp_path / "skills" / "git-workflow"
+        pkg.mkdir(parents=True)
+        versions = find_installed_versions(tmp_path, "skill", "git-workflow")
+        assert versions == []
+
+    def test_not_installed(self, tmp_path):
         (tmp_path / "skills").mkdir(parents=True)
         versions = find_installed_versions(tmp_path, "skill", "nonexistent")
         assert versions == []
@@ -66,11 +87,3 @@ class TestFindInstalledVersions:
     def test_no_directory(self, tmp_path):
         versions = find_installed_versions(tmp_path, "skill", "anything")
         assert versions == []
-
-    def test_ignores_files(self, tmp_path):
-        skills = tmp_path / "skills"
-        skills.mkdir(parents=True)
-        (skills / "git-workflow-1.0.0").mkdir()
-        (skills / "git-workflow-1.0.0.bak").touch()  # file, not dir
-        versions = find_installed_versions(tmp_path, "skill", "git-workflow")
-        assert versions == ["1.0.0"]

--- a/cli/tests/test_resolver.py
+++ b/cli/tests/test_resolver.py
@@ -56,10 +56,8 @@ class TestResolveBasic:
         assert dep_slugs == {"code-review", "security-baseline"}
 
 
-class TestResolveMultiVersion:
-    def test_picks_highest_version(self, strawpot_dir, make_skill):
-        make_skill("git-workflow", "1.0.0")
-        make_skill("git-workflow", "1.4.0")
+class TestResolveSingleVersion:
+    def test_returns_installed_version(self, strawpot_dir, make_skill):
         make_skill("git-workflow", "2.0.0")
 
         result = resolve(
@@ -69,9 +67,7 @@ class TestResolveMultiVersion:
         assert result["version"] == "2.0.0"
 
     def test_dep_version_spec_ignored(self, strawpot_dir, make_skill, make_role):
-        """Version specs in deps are stripped; resolver picks highest installed."""
-        make_skill("git-workflow", "1.0.0")
-        make_skill("git-workflow", "1.4.0")
+        """Version specs in deps are stripped; resolver uses installed version."""
         make_skill("git-workflow", "2.0.0")
         make_role("implementer", "1.0.0", skill_deps=["git-workflow==1.0.0"])
 
@@ -80,12 +76,10 @@ class TestResolveMultiVersion:
             local_root=strawpot_dir, global_root=strawpot_dir,
         )
         gw = next(d for d in result["dependencies"] if d["slug"] == "git-workflow")
-        # Version constraint is ignored; picks highest
         assert gw["version"] == "2.0.0"
 
-    def test_bare_slug_dep_picks_highest(self, strawpot_dir, make_skill, make_role):
-        """Bare slug deps pick the highest installed version."""
-        make_skill("git-workflow", "1.0.0")
+    def test_bare_slug_dep_resolves(self, strawpot_dir, make_skill, make_role):
+        """Bare slug deps resolve the installed version."""
         make_skill("git-workflow", "2.0.0")
         make_role("reviewer", "1.0.0", skill_deps=["git-workflow"])
 
@@ -97,14 +91,13 @@ class TestResolveMultiVersion:
         assert gw["version"] == "2.0.0"
 
     def test_resolve_specific_version(self, strawpot_dir, make_skill):
-        make_skill("git-workflow", "1.0.0")
         make_skill("git-workflow", "2.0.0")
 
         result = resolve(
-            "git-workflow", kind="skill", version="1.0.0",
+            "git-workflow", kind="skill", version="2.0.0",
             local_root=strawpot_dir, global_root=strawpot_dir,
         )
-        assert result["version"] == "1.0.0"
+        assert result["version"] == "2.0.0"
 
 
 class TestResolveCrossScope:
@@ -113,18 +106,20 @@ class TestResolveCrossScope:
         glob = tmp_path / "global"
 
         # v1.0.0 in global
-        d = glob / "skills" / "git-workflow-1.0.0"
+        d = glob / "skills" / "git-workflow"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             '---\nname: git-workflow\ndescription: "v1"\n---\n# GW\n'
         )
+        (d / ".version").write_text("1.0.0\n")
 
         # v1.2.0 in local
-        d = local / "skills" / "git-workflow-1.2.0"
+        d = local / "skills" / "git-workflow"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             '---\nname: git-workflow\ndescription: "v1.2"\n---\n# GW\n'
         )
+        (d / ".version").write_text("1.2.0\n")
 
         result = resolve(
             "git-workflow", kind="skill",
@@ -138,17 +133,19 @@ class TestResolveCrossScope:
         local = tmp_path / "local"
         glob = tmp_path / "global"
 
-        d = local / "skills" / "git-workflow-1.0.0"
+        d = local / "skills" / "git-workflow"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             '---\nname: git-workflow\ndescription: "v1"\n---\n# GW\n'
         )
+        (d / ".version").write_text("1.0.0\n")
 
-        d = glob / "skills" / "git-workflow-2.0.0"
+        d = glob / "skills" / "git-workflow"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             '---\nname: git-workflow\ndescription: "v2"\n---\n# GW\n'
         )
+        (d / ".version").write_text("2.0.0\n")
 
         result = resolve(
             "git-workflow", kind="skill",
@@ -176,17 +173,19 @@ class TestResolveErrors:
 
     def test_circular_dependency(self, strawpot_dir):
         """Two skills that depend on each other."""
-        d = strawpot_dir / "skills" / "a-1.0.0"
+        d = strawpot_dir / "skills" / "a"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             "---\nname: a\ndescription: \"a\"\nmetadata:\n  strawpot:\n    dependencies:\n      - b\n---\n# A\n"
         )
+        (d / ".version").write_text("1.0.0\n")
 
-        d = strawpot_dir / "skills" / "b-1.0.0"
+        d = strawpot_dir / "skills" / "b"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
             "---\nname: b\ndescription: \"b\"\nmetadata:\n  strawpot:\n    dependencies:\n      - a\n---\n# B\n"
         )
+        (d / ".version").write_text("1.0.0\n")
 
         with pytest.raises(DependencyError, match="Circular dependency"):
             resolve(

--- a/cli/tests/test_tools.py
+++ b/cli/tests/test_tools.py
@@ -265,7 +265,7 @@ class TestRunToolInstalls:
 
 class TestRunToolInstallsForPackage:
     def test_reads_skill_md_and_runs_installs(self, tmp_path):
-        pkg_dir = tmp_path / "skills" / "git-workflow-1.0.0"
+        pkg_dir = tmp_path / "skills" / "git-workflow"
         pkg_dir.mkdir(parents=True)
         (pkg_dir / "SKILL.md").write_text(
             "---\n"
@@ -294,7 +294,7 @@ class TestRunToolInstallsForPackage:
         assert results[0]["status"] == "installed"
 
     def test_returns_empty_when_no_tools(self, tmp_path):
-        pkg_dir = tmp_path / "skills" / "basic-1.0.0"
+        pkg_dir = tmp_path / "skills" / "basic"
         pkg_dir.mkdir(parents=True)
         (pkg_dir / "SKILL.md").write_text(
             "---\nname: basic\n---\n\n# Basic\n"
@@ -312,7 +312,7 @@ class TestRunToolInstallsForPackage:
         assert results == []
 
     def test_reads_role_md(self, tmp_path):
-        pkg_dir = tmp_path / "roles" / "deployer-1.0.0"
+        pkg_dir = tmp_path / "roles" / "deployer"
         pkg_dir.mkdir(parents=True)
         (pkg_dir / "ROLE.md").write_text(
             "---\n"
@@ -346,7 +346,7 @@ class TestRunToolInstallsForAll:
     def test_scans_all_packages(self, tmp_path):
         # Create two skill packages
         for slug in ("skill-a", "skill-b"):
-            pkg_dir = tmp_path / "skills" / f"{slug}-1.0.0"
+            pkg_dir = tmp_path / "skills" / slug
             pkg_dir.mkdir(parents=True)
             (pkg_dir / "SKILL.md").write_text(
                 f"---\nname: {slug}\n"
@@ -379,7 +379,7 @@ class TestRunToolInstallsForAll:
     def test_deduplicates_across_packages(self, tmp_path):
         # Two packages declaring the same tool
         for slug in ("skill-a", "skill-b"):
-            pkg_dir = tmp_path / "skills" / f"{slug}-1.0.0"
+            pkg_dir = tmp_path / "skills" / slug
             pkg_dir.mkdir(parents=True)
             (pkg_dir / "SKILL.md").write_text(
                 f"---\nname: {slug}\n"
@@ -437,7 +437,7 @@ class TestInstallToolsCommand:
         from strawhub.cli import cli
 
         # Create a package with tools
-        pkg_dir = tmp_path / "skills" / "test-1.0.0"
+        pkg_dir = tmp_path / "skills" / "test"
         pkg_dir.mkdir(parents=True)
         (pkg_dir / "SKILL.md").write_text(
             "---\nname: test\n"


### PR DESCRIPTION
## Summary
- Packages now install to `<slug>/` instead of `<slug>-<version>/` (e.g. `skills/git-workflow/` instead of `skills/git-workflow-1.0.0/`)
- Version tracked via `.version` marker file written during download
- Aligns with how strawpot's `resolve_agent`, `resolve_memory`, and skill lookups search for packages
- Companion PR: strawpot/strawpot#117

## Test plan
- [x] All 241 strawhub CLI tests pass
- [ ] Run `strawhub install skill <slug> --global` and verify directory is `<slug>/` with `.version` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)