### PR TITLE
Fix Convex site URL to match production deployment

### DIFF
--- a/src/lib/clawhubImport.ts
+++ b/src/lib/clawhubImport.ts
@@ -2,7 +2,7 @@ import type { GitHubFile } from "./githubImport";
 import JSZip from "jszip";
 
 const CLAWHUB_DOWNLOAD_BASE =
-  "https://wry-manatee-359.convex.site/api/v1/download";
+  "https://descriptive-crab-211.convex.site/api/v1/download";
 
 const INSTALL_HINTS: Record<string, Record<string, string>> = {
   node: {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/v1/:path*",
-      "destination": "https://wry-manatee-359.convex.site/api/v1/:path*"
+      "destination": "https://descriptive-crab-211.convex.site/api/v1/:path*"
     },
     { "source": "/(.*)", "destination": "/" }
   ]


### PR DESCRIPTION
## Summary
- Fix `vercel.json` rewrite destination from `wry-manatee-359.convex.site` (old/dev) to `descriptive-crab-211.convex.site` (production)
- Fix `clawhubImport.ts` download base URL to match
- This was causing all CLI API calls for agents, roles, and memories to return "No matching routes found"

## Test plan
- [x] Verified `curl https://descriptive-crab-211.convex.site/api/v1/agents/strawpot-claude-code` returns valid JSON
- [x] No other references to old URL remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)