### PR TITLE
Make --headless non-interactive and fix package kind consistency

### DIFF
--- a/cli/src/strawhub/__init__.py
+++ b/cli/src/strawhub/__init__.py
@@ -1,3 +1,3 @@
-"""StrawHub CLI - discover, publish, and install agent skills, roles, and agents."""
+"""StrawHub CLI - discover, publish, and install agent skills, roles, agents, and memories."""
 
 __version__ = "0.1.0"

--- a/cli/src/strawhub/commands/install_tools.py
+++ b/cli/src/strawhub/commands/install_tools.py
@@ -24,7 +24,7 @@ from strawhub.tools import run_tool_installs_for_all
 def install_tools(is_global, yes):
     """Install system tools declared by installed packages.
 
-    Scans all installed skills/roles for metadata.strawpot.tools
+    Scans all installed packages for metadata.strawpot.tools
     and runs install commands for any missing tools.
     """
     root = get_root(is_global)

--- a/cli/src/strawhub/commands/list.py
+++ b/cli/src/strawhub/commands/list.py
@@ -21,7 +21,7 @@ from strawhub.errors import StrawHubError
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON")
 def list_cmd(kind, limit, sort, as_json):
-    """List skills, roles, and/or agents."""
+    """List skills, roles, agents, and/or memories."""
     with StrawHubClient() as client:
         try:
             result = {}

--- a/cli/src/strawhub/commands/resolve_cmd.py
+++ b/cli/src/strawhub/commands/resolve_cmd.py
@@ -59,3 +59,21 @@ def resolve_skill(slug, ver, is_global):
 def resolve_role(slug, ver, is_global):
     """Resolve a role to its installed path and dependency paths."""
     _resolve_impl(slug, kind="role", ver=ver, is_global=is_global)
+
+
+@resolve_cmd.command("agent")
+@click.argument("slug")
+@click.option("--version", "ver", default=None, help="Resolve a specific version")
+@click.option("--global", "is_global", is_flag=True, default=False, help="Only search global directory")
+def resolve_agent(slug, ver, is_global):
+    """Resolve an agent to its installed path and dependency paths."""
+    _resolve_impl(slug, kind="agent", ver=ver, is_global=is_global)
+
+
+@resolve_cmd.command("memory")
+@click.argument("slug")
+@click.option("--version", "ver", default=None, help="Resolve a specific version")
+@click.option("--global", "is_global", is_flag=True, default=False, help="Only search global directory")
+def resolve_memory(slug, ver, is_global):
+    """Resolve a memory provider to its installed path and dependency paths."""
+    _resolve_impl(slug, kind="memory", ver=ver, is_global=is_global)

--- a/cli/src/strawhub/commands/search.py
+++ b/cli/src/strawhub/commands/search.py
@@ -13,7 +13,7 @@ from strawhub.errors import StrawHubError
 @click.option("--limit", type=int, default=20, help="Max results (1-100)")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON")
 def search(query, kind, limit, as_json):
-    """Search for skills, roles, and agents."""
+    """Search for skills, roles, agents, and memories."""
     with StrawHubClient() as client:
         try:
             data = client.search(query, kind=kind, limit=limit)

--- a/cli/src/strawhub/display.py
+++ b/cli/src/strawhub/display.py
@@ -70,14 +70,14 @@ def print_detail(kind: str, detail: dict) -> None:
                 console.print(f"  - {f['path']} ({f['size']} bytes)")
 
     deps = detail.get("dependencies", {})
-    skill_deps = deps.get("skills", [])
-    role_deps = deps.get("roles", [])
-    if skill_deps or role_deps:
+    all_deps = []
+    for dep_kind in ("skills", "roles", "agents", "memories"):
+        for d in deps.get(dep_kind, []):
+            all_deps.append((dep_kind.rstrip("s"), d))
+    if all_deps:
         console.print("[bold]Dependencies:[/bold]")
-        for d in skill_deps:
-            console.print(f"  - skill: {d}")
-        for d in role_deps:
-            console.print(f"  - role: {d}")
+        for dep_kind, d in all_deps:
+            console.print(f"  - {dep_kind}: {d}")
 
     stats = detail.get("stats", {})
     console.print(

--- a/cli/src/strawhub/frontmatter.py
+++ b/cli/src/strawhub/frontmatter.py
@@ -210,6 +210,7 @@ def extract_dependencies(
     Reads from metadata.strawpot.dependencies.
     For skills: returns {"skills": [...]} from a flat array.
     For roles: returns {"skills": [...], "roles": [...]} from a nested object.
+    For agents and memories: returns None (no dependency support).
     """
     deps = (
         fm.get("metadata", {})

--- a/cli/src/strawhub/lockfile.py
+++ b/cli/src/strawhub/lockfile.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class PackageRef:
-    kind: str  # "skill" or "role"
+    kind: str  # "skill", "role", "agent", or "memory"
     slug: str
     version: str
 

--- a/cli/src/strawhub/paths.py
+++ b/cli/src/strawhub/paths.py
@@ -50,6 +50,14 @@ def get_roles_dir(root: Path) -> Path:
     return root / "roles"
 
 
+def get_agents_dir(root: Path) -> Path:
+    return root / "agents"
+
+
+def get_memories_dir(root: Path) -> Path:
+    return root / "memories"
+
+
 def get_lockfile_path(root: Path) -> Path:
     return root / "strawpot.lock"
 

--- a/cli/src/strawhub/resolver.py
+++ b/cli/src/strawhub/resolver.py
@@ -1,8 +1,8 @@
 """Runtime dependency resolution — selects paths to installed versions.
 
 Scans local .strawpot/ first, then global, to build an index of installed packages.
-For a given root package, reads its SKILL.md/ROLE.md frontmatter to get dependency
-slugs, then selects the highest installed version for each.
+For a given root package, reads its frontmatter (SKILL.md, ROLE.md, AGENT.md, or
+MEMORY.md) to get dependency slugs, then selects the highest installed version for each.
 
 Importable as: from strawhub.resolver import resolve
 """
@@ -123,7 +123,7 @@ def resolve(
         best_version, best_path, best_source = pkg_candidates[0]
 
         # Read frontmatter to get dependency slugs
-        main_file = "SKILL.md" if pkg_kind == "skill" else "ROLE.md"
+        main_file = {"skill": "SKILL.md", "role": "ROLE.md", "agent": "AGENT.md", "memory": "MEMORY.md"}[pkg_kind]
         main_path = Path(best_path) / main_file
         deps_slugs = _read_dependency_slugs(main_path, pkg_kind)
 
@@ -178,8 +178,8 @@ def _build_index(
     index: dict[tuple[str, str], list[tuple[str, str, str]]] = {}
 
     for scope, root in [("local", local_root), ("global", global_root)]:
-        for kind in ["skill", "role"]:
-            subdir = root / ("skills" if kind == "skill" else "roles")
+        for kind in ["skill", "role", "agent", "memory"]:
+            subdir = root / {"skill": "skills", "role": "roles", "agent": "agents", "memory": "memories"}[kind]
             if not subdir.is_dir():
                 continue
             for entry in subdir.iterdir():
@@ -203,7 +203,7 @@ def _build_index(
 def _read_dependency_slugs(
     main_file_path: Path, kind: str
 ) -> list[tuple[str, str]]:
-    """Read dependency slugs from a SKILL.md or ROLE.md file.
+    """Read dependency slugs from a package's main markdown file.
 
     Returns list of (dep_kind, slug) tuples.
     """

--- a/cli/src/strawhub/tools.py
+++ b/cli/src/strawhub/tools.py
@@ -1,7 +1,7 @@
 """System tool dependency management for installed packages.
 
-Reads metadata.strawpot.tools from SKILL.md / ROLE.md frontmatter and
-installs missing tools via OS-specific commands.
+Reads metadata.strawpot.tools from package frontmatter (SKILL.md, ROLE.md,
+AGENT.md, or MEMORY.md) and installs missing tools via OS-specific commands.
 
 Example frontmatter:
     metadata:
@@ -158,7 +158,7 @@ def run_tool_installs_for_package(
 ) -> list[dict]:
     """Extract tools from a downloaded package and run installs."""
     pkg_dir = get_package_dir(root, kind, slug)
-    main_file = "SKILL.md" if kind == "skill" else "ROLE.md"
+    main_file = {"skill": "SKILL.md", "role": "ROLE.md", "agent": "AGENT.md", "memory": "MEMORY.md"}[kind]
     md_path = pkg_dir / main_file
 
     if not md_path.is_file():


### PR DESCRIPTION
## Summary
- Add `auto_setup` parameter to bootstrap helpers (`_ensure_agent_installed`, `_ensure_skill_installed`, `_ensure_memory_installed`) so `--headless` mode auto-installs without prompting
- Fail fast with `sys.exit(1)` on missing env vars in headless mode instead of hanging on `click.prompt()`
- Pass `headless` flag to `Session` for non-interactive merge conflict resolution (auto-discard)
- Fix help text for `install`, `uninstall`, `list`, `publish` passthrough commands to mention all 4 package kinds (skill, role, agent, memory)
- Fix `context.py` to handle agent/memory main files (`AGENT.md`, `MEMORY.md`) in `validate_frontmatter_slug` and `_read_body`

## Test plan
- [x] 3 new `auto_setup` tests in `test_cli_bootstrap.py` verify install without prompting
- [x] 3 new headless tests in `test_cli_headless.py` verify env var failure + auto_setup passthrough
- [x] All 484 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)