### PR TITLE
Fix CLAWHUB_DOWNLOAD_BASE to target ClawHub Convex site

### DIFF
--- a/src/lib/clawhubImport.ts
+++ b/src/lib/clawhubImport.ts
@@ -2,7 +2,7 @@ import type { GitHubFile } from "./githubImport";
 import JSZip from "jszip";
 
 const CLAWHUB_DOWNLOAD_BASE =
-  "https://descriptive-crab-211.convex.site/api/v1/download";
+  "https://wry-manatee-359.convex.site/api/v1/download";
 
 const INSTALL_HINTS: Record<string, Record<string, string>> = {
   node: {


### PR DESCRIPTION
## Summary
- **Fixed `CLAWHUB_DOWNLOAD_BASE`** in `src/lib/clawhubImport.ts` to point to ClawHub's Convex deployment (`wry-manatee-359.convex.site`) instead of StrawHub's own (`descriptive-crab-211.convex.site`)

## Test plan
- [ ] Verify ClawHub skill import works by importing a skill from a `clawhub.ai` URL
- [ ] Confirm the download endpoint responds correctly at the new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)