### PR TITLE
Fix wildcard dependency resolution causing 400 on install

### DIFF
--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -113,6 +113,7 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
     }
     const spec = parseDependencySpec(depSpec);
+    if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `skill:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
     if (visiting.has(key)) {
@@ -153,6 +154,7 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
     }
     const spec = parseDependencySpec(depSpec);
+    if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `role:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
     if (visiting.has(key)) {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -114,6 +114,7 @@ export async function handleResolveSkillDeps(ctx: any, request: Request): Promis
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
     }
     const spec = parseDependencySpec(depSpec);
+    if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `skill:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
     if (visiting.has(key)) {


### PR DESCRIPTION
## Summary
- Skip wildcard `*` dependency specs in server-side resolve endpoints (`rolesV1.ts`, `skillsV1.ts`)
- Fixes `Error: API error 400: Dependency role '*' not found` when installing roles like `ai-ceo` that declare `"*"` in their role dependencies
- The CLI already filters wildcards post-response, but the server threw before sending the response

## Test plan
- [x] `versionSpec.test.ts` passes (22 tests)
- [ ] Manual: `strawpot start` successfully installs `ai-ceo` role without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)