### PR TITLE
Rename default agent from claude_code to strawpot-claude-code

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,7 +113,7 @@ metadata:
         - code-review
       roles:
         - reviewer
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ That's it. StrawHub resolves every skill and sub-role your AI CEO needs. StrawPo
 │                                             │
 │   Agents                                    │
 │  ┌──────────────────────────────┐           │
-│  │claude_code · codex · gemini  │           │
+│  │strawpot-claude-code · codex · gemini  │           │
 │  └──────────────────────────────┘           │
 └─────────────────────────────────────────────┘
 ```
@@ -98,7 +98,7 @@ metadata:
   strawpot:
     dependencies:
       roles: [pm, implementer, reviewer]
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # CEO
@@ -186,7 +186,7 @@ User task → StrawPot runtime → Role (ai-ceo)
                                  │   └─ Skills (project-planning, task-breakdown)
                                  ├─ Sub-role (implementer)
                                  │   ├─ Skills (git-workflow, python-dev)
-                                 │   └─ Agent (claude_code)
+                                 │   └─ Agent (strawpot-claude-code)
                                  └─ Sub-role (reviewer)
                                      ├─ Skills (code-review, security-baseline)
                                      └─ Agent (gemini)

--- a/cli/tests/test_frontmatter.py
+++ b/cli/tests/test_frontmatter.py
@@ -156,14 +156,14 @@ class TestParseFrontmatter:
             "name: implementer\n"
             "metadata:\n"
             "  strawpot:\n"
-            "    default_agent: claude_code\n"
+            "    default_agent: strawpot-claude-code\n"
             "---\n"
             "Body.\n"
         )
         result = parse_frontmatter(text)
         assert result["frontmatter"]["metadata"] == {
             "strawpot": {
-                "default_agent": "claude_code",
+                "default_agent": "strawpot-claude-code",
             },
         }
 

--- a/convex/lib/frontmatter.test.ts
+++ b/convex/lib/frontmatter.test.ts
@@ -232,14 +232,14 @@ Body.
 name: implementer
 metadata:
   strawpot:
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 Body.
 `;
     const result = parseFrontmatter(text);
     expect(result.frontmatter.metadata).toEqual({
       strawpot: {
-        default_agent: "claude_code",
+        default_agent: "strawpot-claude-code",
       },
     });
   });

--- a/docs/content-format.md
+++ b/docs/content-format.md
@@ -68,7 +68,7 @@ metadata:
         - python-testing
       roles:
         - reviewer
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Implementer

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -55,7 +55,7 @@ metadata:
         - python-testing
       roles:
         - reviewer
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ```
 
 ### Agents

--- a/src/lib/parseFrontmatter.test.ts
+++ b/src/lib/parseFrontmatter.test.ts
@@ -188,14 +188,14 @@ Body.
 name: implementer
 metadata:
   strawpot:
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 Body.
 `;
     const result = parseFrontmatter(text);
     expect(result.frontmatter.metadata).toEqual({
       strawpot: {
-        default_agent: "claude_code",
+        default_agent: "strawpot-claude-code",
       },
     });
   });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -104,7 +104,7 @@ function HomePage() {
  │   ├─ extract-data
  │   └─ report-writing
  └─ default_agent
-     └─ claude_code`}</code></pre>
+     └─ strawpot-claude-code`}</code></pre>
           <p className="text-gray-500 text-sm mt-3">
             One install resolves everything.
           </p>

--- a/tests/fixtures/roles/documenter/ROLE.md
+++ b/tests/fixtures/roles/documenter/ROLE.md
@@ -6,7 +6,7 @@ metadata:
   tags: [documentation, writing]
   author: strawpot
   strawpot:
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Documenter

--- a/tests/fixtures/roles/fixer/ROLE.md
+++ b/tests/fixtures/roles/fixer/ROLE.md
@@ -6,7 +6,7 @@ metadata:
     dependencies:
       skills:
         - git-workflow
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Fixer

--- a/tests/fixtures/roles/implementer/ROLE.md
+++ b/tests/fixtures/roles/implementer/ROLE.md
@@ -8,7 +8,7 @@ metadata:
         - git-workflow
         - code-review
         - python-testing
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Implementer

--- a/tests/fixtures/roles/planner/ROLE.md
+++ b/tests/fixtures/roles/planner/ROLE.md
@@ -6,7 +6,7 @@ metadata:
   tags: [planning, architecture]
   author: strawpot
   strawpot:
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Planner

--- a/tests/fixtures/roles/reviewer/ROLE.md
+++ b/tests/fixtures/roles/reviewer/ROLE.md
@@ -7,7 +7,7 @@ metadata:
       skills:
         - code-review
         - security-baseline
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Reviewer


### PR DESCRIPTION
## Summary
- Rename all `claude_code` agent/runtime identifiers to `strawpot-claude-code` across docs, fixtures, and tests
- Aligns with strawpot's `config.py` default and the matching PRs in [strawpot#126](https://github.com/strawpot/strawpot/pull/126) and [roles#4](https://github.com/strawpot/roles/pull/4)
- The compiled binary `strawpot_claude_code` is unchanged

**13 files updated:** DESIGN.md, README, docs (2), source (1), test fixtures (5), tests (3)

## Test plan
- [ ] Run `bun test` to verify frontmatter parsing tests pass
- [ ] Run `pytest cli/tests/` to verify CLI frontmatter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)