### PR TITLE
Add link to strawpot.com on homepage

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,7 +17,7 @@ function HomePage() {
         <h1 className="text-3xl md:text-5xl font-bold text-white mb-4">StrawHub</h1>
         <p className="text-lg md:text-xl text-gray-400 mb-4">
           The registry for{" "}
-          <span className="text-orange-400">StrawPot</span> — where AI agents
+          <a href="https://strawpot.com" target="_blank" rel="noopener noreferrer" className="text-orange-400">StrawPot</a> — where AI agents
           get the job done
         </p>
         <p className="text-gray-500 max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary
- Link the "StrawPot" text on the homepage to https://strawpot.com
- Opens in a new tab with `target="_blank"` and `rel="noopener noreferrer"`
- Preserves existing orange text styling

## Test plan
- [ ] Verify the StrawPot link on the homepage navigates to https://strawpot.com
- [ ] Verify it opens in a new tab
- [ ] Verify the text style is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)