### PR TITLE
Increase max file count to 100 for skills, agents, memories

### DIFF
--- a/convex/lib/publishValidation.test.ts
+++ b/convex/lib/publishValidation.test.ts
@@ -134,7 +134,7 @@ describe("validateFiles", () => {
         size: 100,
       })),
     ];
-    expect(() => validateFiles(files)).toThrow(/Maximum 50 files/);
+    expect(() => validateFiles(files)).toThrow(/Maximum 100 files/);
   });
 
   it("accepts exactly MAX_FILE_COUNT files", () => {

--- a/convex/lib/publishValidation.ts
+++ b/convex/lib/publishValidation.ts
@@ -12,12 +12,12 @@ export const MAX_DISPLAY_NAME_LENGTH = 128;
 export const MAX_CHANGELOG_LENGTH = 10_000;
 export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
 export const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB total
-export const MAX_FILE_COUNT = 50;
+export const MAX_FILE_COUNT = 100;
 
 // Agent-specific limits (agents may include compiled binaries)
 export const AGENT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
 export const AGENT_MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB total
-export const AGENT_MAX_FILE_COUNT = 50;
+export const AGENT_MAX_FILE_COUNT = 100;
 
 // Memory-specific limits (same as agent — may include binary files)
 export const MEMORY_MAX_FILE_SIZE = AGENT_MAX_FILE_SIZE;


### PR DESCRIPTION
## Summary
- Increased `MAX_FILE_COUNT` and `AGENT_MAX_FILE_COUNT` from 50 to 100 (`MEMORY_MAX_FILE_COUNT` derives from agent limit automatically)
- Updated test assertion to match new limit

## Test plan
- [x] All 51 `publishValidation` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)