### PR TITLE
Add --root option to specify project directory

### DIFF
--- a/cli/src/strawhub/cli.py
+++ b/cli/src/strawhub/cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 
 from strawhub import __version__
@@ -22,8 +24,19 @@ from strawhub.commands.install_tools import install_tools
 
 @click.group()
 @click.version_option(version=__version__, prog_name="strawhub")
-def cli():
+@click.option(
+    "--root",
+    "root_dir",
+    default=None,
+    type=click.Path(exists=True, file_okay=False),
+    help="Project directory (default: current directory)",
+)
+def cli(root_dir):
     """StrawHub CLI - discover and install agent skills, roles, agents, and memories."""
+    if root_dir:
+        from strawhub.paths import set_local_root
+
+        set_local_root(Path(root_dir) / ".strawpot")
 
 
 cli.add_command(login)

--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -68,6 +68,12 @@ def _install_impl(
     save=False,
     save_exact=False,
 ):
+    from strawhub.paths import _local_root_override
+
+    if is_global and _local_root_override is not None:
+        print_error("--root and --global cannot be used together")
+        raise SystemExit(1)
+
     root = get_root(is_global)
     lockfile = Lockfile.load(get_lockfile_path(root))
 

--- a/cli/src/strawhub/commands/install_tools.py
+++ b/cli/src/strawhub/commands/install_tools.py
@@ -27,6 +27,12 @@ def install_tools(is_global, yes):
     Scans all installed packages for metadata.strawpot.tools
     and runs install commands for any missing tools.
     """
+    from strawhub.paths import _local_root_override
+
+    if is_global and _local_root_override is not None:
+        print_error("--root and --global cannot be used together")
+        raise SystemExit(1)
+
     root = get_root(is_global)
     lockfile = Lockfile.load(get_lockfile_path(root))
 

--- a/cli/src/strawhub/commands/uninstall.py
+++ b/cli/src/strawhub/commands/uninstall.py
@@ -23,6 +23,11 @@ def uninstall(ctx):
 
 
 def _uninstall_impl(slug, kind, ver, is_global, save=False):
+    from strawhub.paths import _local_root_override
+
+    if is_global and _local_root_override is not None:
+        print_error("--root and --global cannot be used together")
+        raise SystemExit(1)
     if save and is_global:
         print_error("--save cannot be used with --global")
         raise SystemExit(1)

--- a/cli/src/strawhub/commands/update.py
+++ b/cli/src/strawhub/commands/update.py
@@ -72,6 +72,12 @@ def _save_updated_version(kind: str, slug: str) -> None:
 
 
 def _update_all_impl(is_global, skip_tools=False, yes=False, save=False):
+    from strawhub.paths import _local_root_override
+
+    if is_global and _local_root_override is not None:
+        print_error("--root and --global cannot be used together")
+        raise SystemExit(1)
+
     root = get_root(is_global)
     lockfile = Lockfile.load(get_lockfile_path(root))
 
@@ -93,6 +99,11 @@ def _update_all_impl(is_global, skip_tools=False, yes=False, save=False):
 
 
 def _update_one_impl(slug, kind, is_global, skip_tools=False, yes=False, save=False):
+    from strawhub.paths import _local_root_override
+
+    if is_global and _local_root_override is not None:
+        print_error("--root and --global cannot be used together")
+        raise SystemExit(1)
     if save and is_global:
         print_error("--save cannot be used with --global")
         raise SystemExit(1)

--- a/cli/src/strawhub/paths.py
+++ b/cli/src/strawhub/paths.py
@@ -1,7 +1,7 @@
 """Path resolution for .strawpot directories.
 
 Global root: STRAWPOT_HOME env var → ~/.strawpot (default)
-Local root:  ./.strawpot in the current working directory
+Local root:  ./.strawpot in the current working directory (or --root override)
 """
 
 import os
@@ -15,9 +15,23 @@ _KIND_SUBDIRS = {
     "memory": "memories",
 }
 
+# Module-level override set by ``--root`` CLI option.
+_local_root_override: Path | None = None
+
+
+def set_local_root(path: Path | None) -> None:
+    """Override the local root directory.
+
+    Called by the CLI ``--root`` option.  Pass ``None`` to reset.
+    """
+    global _local_root_override
+    _local_root_override = path
+
 
 def get_project_file_path() -> Path:
-    """Return the path to strawpot.toml in the current working directory."""
+    """Return the path to strawpot.toml in the project directory."""
+    if _local_root_override is not None:
+        return _local_root_override.parent / "strawpot.toml"
     return Path.cwd() / "strawpot.toml"
 
 
@@ -33,7 +47,13 @@ def get_global_root() -> Path:
 
 
 def get_local_root() -> Path:
-    """Return the local .strawpot root in the current working directory."""
+    """Return the local .strawpot root.
+
+    Uses the ``--root`` override if set, otherwise falls back to
+    ``./.strawpot`` in the current working directory.
+    """
+    if _local_root_override is not None:
+        return _local_root_override
     return Path.cwd() / ".strawpot"
 
 

--- a/cli/tests/test_root_option.py
+++ b/cli/tests/test_root_option.py
@@ -1,0 +1,30 @@
+"""Tests for the --root CLI option."""
+
+from pathlib import Path
+
+from strawhub.paths import get_local_root, get_project_file_path, set_local_root
+
+
+class TestSetLocalRoot:
+    def teardown_method(self):
+        set_local_root(None)
+
+    def test_override_local_root(self, tmp_path):
+        override = tmp_path / ".strawpot"
+        set_local_root(override)
+        assert get_local_root() == override
+
+    def test_override_project_file_path(self, tmp_path):
+        override = tmp_path / ".strawpot"
+        set_local_root(override)
+        assert get_project_file_path() == tmp_path / "strawpot.toml"
+
+    def test_reset_clears_override(self, tmp_path):
+        set_local_root(tmp_path / ".strawpot")
+        set_local_root(None)
+        assert get_local_root() == Path.cwd() / ".strawpot"
+        assert get_project_file_path() == Path.cwd() / "strawpot.toml"
+
+    def test_default_without_override(self):
+        assert get_local_root() == Path.cwd() / ".strawpot"
+        assert get_project_file_path() == Path.cwd() / "strawpot.toml"


### PR DESCRIPTION
## Summary
- Add top-level `--root <path>` CLI option that overrides the local `.strawpot` root
- `strawhub --root /path/to/project install skill X` installs to `/path/to/project/.strawpot/skills/X/`
- `get_project_file_path()` also respects the override (`/path/to/project/strawpot.toml`)
- Mutually exclusive with `--global` (checked in install, uninstall, update, install-tools)
- Enables the GUI backend to manage project-scoped resources without `cwd` hacking

## Test plan
- [ ] `strawhub --root /tmp/test install skill X` installs to `/tmp/test/.strawpot/`
- [ ] `strawhub --root /tmp/test --global install skill X` errors
- [ ] `strawhub install skill X` unchanged (uses cwd)
- [ ] All 249 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)