### PR TITLE
Run package install scripts during strawhub install

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -19,7 +19,7 @@ from strawhub.paths import (
     get_installed_version,
 )
 from strawhub.project_file import ProjectFile
-from strawhub.tools import run_tool_installs_for_package
+from strawhub.tools import run_package_install, run_tool_installs_for_package
 from strawhub.version_spec import (
     DependencySpec,
     extract_slug,
@@ -272,6 +272,14 @@ def _install_impl(
                 console.print(
                     f"Saved {kind} '{slug}' ({constraint}) to strawpot.toml"
                 )
+
+            # Run package install scripts (non-fatal)
+            if not skip_tools:
+                for dep in installed_deps:
+                    run_package_install(
+                        root, dep["kind"], dep["slug"], yes=yes
+                    )
+                run_package_install(root, kind, slug, yes=yes)
 
             # Run tool installs (non-fatal)
             if not skip_tools:

--- a/cli/src/strawhub/tools.py
+++ b/cli/src/strawhub/tools.py
@@ -148,6 +148,69 @@ def run_tool_installs(
     return results
 
 
+def run_package_install(
+    root: Path,
+    kind: str,
+    slug: str,
+    yes: bool = False,
+) -> dict | None:
+    """Run metadata.strawpot.install.<os> for a downloaded package.
+
+    This is the package's own install script (e.g. compile a binary),
+    distinct from tool installs which install external dependencies.
+
+    Returns a result dict or None if no install command is defined.
+    """
+    pkg_dir = get_package_dir(root, kind, slug)
+    main_file = {"skill": "SKILL.md", "role": "ROLE.md", "agent": "AGENT.md", "memory": "MEMORY.md"}[kind]
+    md_path = pkg_dir / main_file
+
+    if not md_path.is_file():
+        return None
+
+    parsed = parse_frontmatter(md_path.read_text(encoding="utf-8"))
+    fm = parsed.get("frontmatter", {})
+    install_map = fm.get("metadata", {}).get("strawpot", {}).get("install", {})
+    if not isinstance(install_map, dict):
+        return None
+
+    current_os = detect_os()
+    if current_os is None:
+        return None
+
+    command = install_map.get(current_os)
+    if not command:
+        return None
+
+    if not yes:
+        confirmed = click.confirm(
+            f"  Run install script for {kind} '{slug}'? Command: {command}",
+            default=True,
+        )
+        if not confirmed:
+            return {"package": slug, "status": "declined", "command": command}
+
+    console.print(f"  Running install for {kind} '{slug}': {command}")
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,  # noqa: S602
+            cwd=str(pkg_dir),
+            env={**__import__("os").environ, "INSTALL_DIR": str(pkg_dir)},
+        )
+        if proc.returncode == 0:
+            console.print(f"  [green]Install complete for '{slug}'[/green]")
+            return {"package": slug, "status": "installed", "command": command}
+        else:
+            print_error(
+                f"Install script for '{slug}' failed (exit code {proc.returncode})."
+            )
+            return {"package": slug, "status": "failed", "command": command}
+    except OSError as e:
+        print_error(f"Failed to run install for '{slug}': {e}")
+        return {"package": slug, "status": "failed", "command": command}
+
+
 def run_tool_installs_for_package(
     root: Path,
     kind: str,


### PR DESCRIPTION
## Summary
- Add `run_package_install()` to `tools.py` that reads `metadata.strawpot.install.<os>` from package frontmatter and executes the OS-specific install command
- Call `run_package_install()` in `install.py` for both dependencies and the root package after download, before tool installs
- Previously only `metadata.strawpot.tools.<tool>.install` was handled; `metadata.strawpot.install` (the package's own build/setup script) was never invoked

## Test plan
- [x] All 249 existing tests pass
- [ ] Install an agent with `metadata.strawpot.install.macos` defined and verify the install script runs
- [ ] Verify `metadata.strawpot.tools` installs still work as before
- [ ] Verify `--skip-tools` flag skips both package install and tool installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)