### PR TITLE
Update install command to pip install strawpot

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ AI agents are powerful. But every team reinvents the wheel:
 ## Quick Start
 
 ```bash
-pip install strawpot-gui
+pip install strawpot
 
 strawhub install role ai-ceo
 strawpot gui


### PR DESCRIPTION
## Summary

- Replace `pip install strawpot-gui` with `pip install strawpot` in Quick Start
- The GUI dashboard is now included as a dependency of the main `strawpot` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)