### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Browse, install, and publish the roles, skills, agents, and memories that power 
 
 <p align="center">
   <a href="https://github.com/strawpot/strawhub/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/strawpot/strawhub/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
-  <a href="https://discord.gg/buEbvEMC"><img src="https://img.shields.io/discord/1476285531464929505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
+  <a href="https://discord.gg/2BRsCRUrKb"><img src="https://img.shields.io/discord/1476285531464929505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -136,4 +136,4 @@ Settings can also be persisted in `~/.config/strawhub/config.json`.
 
 - **Registry**: <https://strawhub.dev>
 - **Source**: <https://github.com/strawpot/strawhub>
-- **Discord**: <https://discord.gg/buEbvEMC>
+- **Discord**: <https://discord.gg/2BRsCRUrKb>

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 Homepage = "https://strawhub.dev"
 Repository = "https://github.com/strawpot/strawhub"
 Documentation = "https://github.com/strawpot/strawhub/blob/main/docs/http-api.md"
-Discord = "https://discord.gg/buEbvEMC"
+Discord = "https://discord.gg/2BRsCRUrKb"
 
 [project.scripts]
 strawhub = "strawhub.cli:cli"


### PR DESCRIPTION
## Summary
- Replace old Discord invite link (`buEbvEMC`) with new one (`2BRsCRUrKb`) in README, cli/README, and cli/pyproject.toml

## Test plan
- [ ] Verify Discord badge link in README points to new invite
- [ ] Verify cli/README links section points to new invite
- [ ] Verify pyproject.toml project URL points to new invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)