### PR TITLE
Fix AttributeError when metadata.strawpot is null or non-dict

### DIFF
--- a/cli/src/strawhub/frontmatter.py
+++ b/cli/src/strawhub/frontmatter.py
@@ -212,11 +212,13 @@ def extract_dependencies(
     For roles: returns {"skills": [...], "roles": [...]} from a nested object.
     For agents and memories: returns None (no dependency support).
     """
-    deps = (
-        fm.get("metadata", {})
-        .get("strawpot", {})
-        .get("dependencies")
-    )
+    metadata = fm.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    strawpot_meta = metadata.get("strawpot")
+    if not isinstance(strawpot_meta, dict):
+        return None
+    deps = strawpot_meta.get("dependencies")
 
     if deps is None or kind in ("agent", "memory"):
         return None

--- a/cli/src/strawhub/tools.py
+++ b/cli/src/strawhub/tools.py
@@ -170,7 +170,9 @@ def run_package_install(
 
     parsed = parse_frontmatter(md_path.read_text(encoding="utf-8"))
     fm = parsed.get("frontmatter", {})
-    install_map = fm.get("metadata", {}).get("strawpot", {}).get("install", {})
+    metadata = fm.get("metadata")
+    sp = metadata.get("strawpot") if isinstance(metadata, dict) else None
+    install_map = sp.get("install", {}) if isinstance(sp, dict) else {}
     if not isinstance(install_map, dict):
         return None
 


### PR DESCRIPTION
## Summary

- `extract_dependencies()` in `frontmatter.py` crashed with `AttributeError: 'str' object has no attribute 'get'` when a skill's `SKILL.md` had an empty `strawpot:` key (e.g. `metadata:\n  strawpot:`)
- The custom frontmatter parser returns `""` for YAML null values; chaining `.get()` on a string fails
- Same defensive fix applied to `tools.py`'s `run_package_install()`

**Root cause:** `strawpot-config` and `strawpot-sessions` skill files have `metadata:\n  strawpot:` with no content. This crashed Bot Imu session startup when the `imu` role's skill dependencies were being resolved.

## Test plan

- [ ] Verify `extract_dependencies()` returns `None` gracefully when `metadata.strawpot` is `""` or `None`
- [ ] Verify Bot Imu session starts and spawns the agent (no more immediate `session_end` with `exit_code: 0`)
- [ ] Confirm skills with proper `metadata.strawpot` content still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)