### PR TITLE
Make displayName optional with auto-generation from slug

### DIFF
--- a/cli/src/strawhub/commands/publish.py
+++ b/cli/src/strawhub/commands/publish.py
@@ -46,7 +46,9 @@ def _publish_impl(path, kind, ver, changelog, tags):
         content = rewrite_frontmatter_name(content, slug)
         name_rewritten = True
 
-    display_name = fm.get("displayName") or fm.get("display_name") or slug
+    display_name = fm.get("displayName") or fm.get("display_name") or " ".join(
+        w.capitalize() for w in slug.split("-")
+    )
     version = ver or fm.get("version")
     if not version:
         print_error(

--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -6,7 +6,7 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter } from "./lib/frontmatter";
 import { parseVersion, compareVersions } from "./lib/versionSpec";
 import { paginateWithRecovery } from "./lib/pagination";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles, validateFrontmatterName } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateAgentFiles, validateFrontmatterName, resolveDisplayName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -189,7 +189,7 @@ export const listByOwner = query({
 
 const publishArgs = {
   slug: v.string(),
-  displayName: v.string(),
+  displayName: v.optional(v.string()),
   version: v.optional(v.string()),
   changelog: v.string(),
   files: v.array(
@@ -213,7 +213,6 @@ export const publishInternal = internalMutation({
   args: { ...publishArgs, userId: v.id("users") },
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateAgentFiles(args.files);
 
@@ -235,13 +234,16 @@ export const publishInternal = internalMutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, agent?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (agent) {
       if (agent.ownerUserId !== user._id) throw new Error("You do not own this agent");
       if (agent.softDeletedAt) throw new Error("Agent has been deleted");
     } else {
       const agentId = await ctx.db.insert("agents", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : undefined,
         ownerUserId: user._id,
         tags: {},
@@ -295,7 +297,7 @@ export const publishInternal = internalMutation({
 
     await ctx.db.patch(agent._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : agent.summary,
       tags: currentTags,
       stats: { ...agent.stats, versions: agent.stats.versions + 1 },
@@ -321,7 +323,6 @@ export const publish = mutation({
   args: publishArgs,
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateAgentFiles(args.files);
 
@@ -348,6 +349,9 @@ export const publish = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, agent?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (agent) {
       if (agent.ownerUserId !== user._id) {
         throw new Error("You do not own this agent");
@@ -358,7 +362,7 @@ export const publish = mutation({
     } else {
       const agentId = await ctx.db.insert("agents", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string"
           ? parsed.frontmatter.description
           : undefined,
@@ -421,7 +425,7 @@ export const publish = mutation({
 
     await ctx.db.patch(agent._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string"
         ? parsed.frontmatter.description
         : agent.summary,

--- a/convex/httpApiV1/agentsV1.ts
+++ b/convex/httpApiV1/agentsV1.ts
@@ -124,8 +124,8 @@ export const publishAgent = httpAction(async (ctx, request) => {
     const tagsStr = formData.get("customTags") as string | null;
     if (tagsStr) customTags = tagsStr.split(",").map((s) => s.trim()).filter(Boolean);
 
-    if (!slug || !displayName || !version) {
-      return errorResponse("slug, displayName, and version are required", 400);
+    if (!slug || !version) {
+      return errorResponse("slug and version are required", 400);
     }
 
     // Validate inputs before storing files

--- a/convex/httpApiV1/memoriesV1.ts
+++ b/convex/httpApiV1/memoriesV1.ts
@@ -124,8 +124,8 @@ export const publishMemory = httpAction(async (ctx, request) => {
     const tagsStr = formData.get("customTags") as string | null;
     if (tagsStr) customTags = tagsStr.split(",").map((s) => s.trim()).filter(Boolean);
 
-    if (!slug || !displayName || !version) {
-      return errorResponse("slug, displayName, and version are required", 400);
+    if (!slug || !version) {
+      return errorResponse("slug and version are required", 400);
     }
 
     // Validate inputs before storing files

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -258,8 +258,8 @@ export const publishRole = httpAction(async (ctx, request) => {
       }
     }
 
-    if (!slug || !displayName || !version) {
-      return errorResponse("slug, displayName, and version are required", 400);
+    if (!slug || !version) {
+      return errorResponse("slug and version are required", 400);
     }
 
     // Validate inputs before storing files

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -222,8 +222,8 @@ export const publishSkill = httpAction(async (ctx, request) => {
       }
     }
 
-    if (!slug || !displayName || !version) {
-      return errorResponse("slug, displayName, and version are required", 400);
+    if (!slug || !version) {
+      return errorResponse("slug and version are required", 400);
     }
 
     // Validate inputs before storing files

--- a/convex/lib/publishValidation.ts
+++ b/convex/lib/publishValidation.ts
@@ -45,6 +45,31 @@ export function validateDisplayName(name: string): void {
   }
 }
 
+/**
+ * Generate a display name from a slug by title-casing hyphen-separated words.
+ * e.g. "github-issues" → "Github Issues"
+ */
+export function displayNameFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Resolve the display name: use provided value, fall back to existing, or generate from slug.
+ */
+export function resolveDisplayName(
+  provided: string | undefined,
+  existing: string | undefined,
+  slug: string,
+): string {
+  const trimmed = provided?.trim();
+  if (trimmed) return trimmed;
+  if (existing) return existing;
+  return displayNameFromSlug(slug);
+}
+
 export function validateChangelog(changelog: string): void {
   if (changelog.length > MAX_CHANGELOG_LENGTH) {
     throw new Error(`Changelog must be under ${MAX_CHANGELOG_LENGTH} characters`);

--- a/convex/memories.ts
+++ b/convex/memories.ts
@@ -6,7 +6,7 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter } from "./lib/frontmatter";
 import { parseVersion, compareVersions } from "./lib/versionSpec";
 import { paginateWithRecovery } from "./lib/pagination";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateMemoryFiles, validateFrontmatterName } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateMemoryFiles, validateFrontmatterName, resolveDisplayName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -188,7 +188,7 @@ export const listByOwner = query({
 
 const publishArgs = {
   slug: v.string(),
-  displayName: v.string(),
+  displayName: v.optional(v.string()),
   version: v.optional(v.string()),
   changelog: v.string(),
   files: v.array(
@@ -212,7 +212,6 @@ export const publishInternal = internalMutation({
   args: { ...publishArgs, userId: v.id("users") },
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateMemoryFiles(args.files);
 
@@ -234,13 +233,16 @@ export const publishInternal = internalMutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, memory?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (memory) {
       if (memory.ownerUserId !== user._id) throw new Error("You do not own this memory");
       if (memory.softDeletedAt) throw new Error("Memory has been deleted");
     } else {
       const memoryId = await ctx.db.insert("memories", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : undefined,
         ownerUserId: user._id,
         tags: {},
@@ -294,7 +296,7 @@ export const publishInternal = internalMutation({
 
     await ctx.db.patch(memory._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : memory.summary,
       tags: currentTags,
       stats: { ...memory.stats, versions: memory.stats.versions + 1 },
@@ -320,7 +322,6 @@ export const publish = mutation({
   args: publishArgs,
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateMemoryFiles(args.files);
 
@@ -347,6 +348,9 @@ export const publish = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, memory?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (memory) {
       if (memory.ownerUserId !== user._id) {
         throw new Error("You do not own this memory");
@@ -357,7 +361,7 @@ export const publish = mutation({
     } else {
       const memoryId = await ctx.db.insert("memories", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string"
           ? parsed.frontmatter.description
           : undefined,
@@ -420,7 +424,7 @@ export const publish = mutation({
 
     await ctx.db.patch(memory._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string"
         ? parsed.frontmatter.description
         : memory.summary,

--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -5,7 +5,7 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter, extractDependencies } from "./lib/frontmatter";
 import { parseDependencySpec, parseVersion, compareVersions } from "./lib/versionSpec";
 import { paginateWithRecovery } from "./lib/pagination";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateRoleFiles, validateFrontmatterName } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateRoleFiles, validateFrontmatterName, resolveDisplayName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -197,7 +197,7 @@ export const listByOwner = query({
 
 const publishArgs = {
   slug: v.string(),
-  displayName: v.string(),
+  displayName: v.optional(v.string()),
   version: v.optional(v.string()),
   changelog: v.string(),
   files: v.array(
@@ -227,7 +227,6 @@ export const publishInternal = internalMutation({
   args: { ...publishArgs, userId: v.id("users") },
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateFiles(args.files);
     validateRoleFiles(args.files);
@@ -328,13 +327,16 @@ export const publishInternal = internalMutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, role?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (role) {
       if (role.ownerUserId !== user._id) throw new Error("You do not own this role");
       if (role.softDeletedAt) throw new Error("Role has been deleted");
     } else {
       const roleId = await ctx.db.insert("roles", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : undefined,
         ownerUserId: user._id,
         tags: {},
@@ -389,7 +391,7 @@ export const publishInternal = internalMutation({
 
     await ctx.db.patch(role._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : role.summary,
       tags: currentTags,
       stats: { ...role.stats, versions: role.stats.versions + 1 },
@@ -407,7 +409,6 @@ export const publish = mutation({
   args: publishArgs,
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateFiles(args.files);
     validateRoleFiles(args.files);
@@ -514,6 +515,9 @@ export const publish = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, role?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (role) {
       if (role.ownerUserId !== user._id) {
         throw new Error("You do not own this role");
@@ -524,7 +528,7 @@ export const publish = mutation({
     } else {
       const roleId = await ctx.db.insert("roles", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string"
           ? parsed.frontmatter.description
           : undefined,
@@ -588,7 +592,7 @@ export const publish = mutation({
 
     await ctx.db.patch(role._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string"
         ? parsed.frontmatter.description
         : role.summary,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6,7 +6,7 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { parseFrontmatter, extractDependencies } from "./lib/frontmatter";
 import { parseDependencySpec, parseVersion, compareVersions } from "./lib/versionSpec";
 import { paginateWithRecovery } from "./lib/pagination";
-import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateSkillFiles, validateFrontmatterName } from "./lib/publishValidation";
+import { validateSlug, validateVersion, validateDisplayName, validateChangelog, validateFiles, validateSkillFiles, validateFrontmatterName, resolveDisplayName } from "./lib/publishValidation";
 
 /** Resolve version: validate if provided, otherwise auto-increment from latest. */
 function resolveVersion(explicit: string | undefined, latestVersion: string | undefined): string {
@@ -215,7 +215,7 @@ export const listByOwner = query({
 
 const publishArgs = {
   slug: v.string(),
-  displayName: v.string(),
+  displayName: v.optional(v.string()),
   version: v.optional(v.string()),
   changelog: v.string(),
   files: v.array(
@@ -251,7 +251,6 @@ export const publishInternal = internalMutation({
   args: { ...publishArgs, userId: v.id("users") },
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateFiles(args.files);
     validateSkillFiles(args.files);
@@ -322,6 +321,9 @@ export const publishInternal = internalMutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, skill?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (skill) {
       if (skill.ownerUserId !== user._id) {
         throw new Error("You do not own this skill");
@@ -332,7 +334,7 @@ export const publishInternal = internalMutation({
     } else {
       const skillId = await ctx.db.insert("skills", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string"
           ? parsed.frontmatter.description
           : undefined,
@@ -398,7 +400,7 @@ export const publishInternal = internalMutation({
 
     await ctx.db.patch(skill._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string"
         ? parsed.frontmatter.description
         : skill.summary,
@@ -426,7 +428,6 @@ export const publish = mutation({
   args: publishArgs,
   handler: async (ctx, args) => {
     validateSlug(args.slug);
-    validateDisplayName(args.displayName);
     validateChangelog(args.changelog);
     validateFiles(args.files);
     validateSkillFiles(args.files);
@@ -498,13 +499,16 @@ export const publish = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .first();
 
+    const displayName = resolveDisplayName(args.displayName, skill?.displayName, args.slug);
+    validateDisplayName(displayName);
+
     if (skill) {
       if (skill.ownerUserId !== user._id) throw new Error("You do not own this skill");
       if (skill.softDeletedAt) throw new Error("Skill has been deleted");
     } else {
       const skillId = await ctx.db.insert("skills", {
         slug: args.slug,
-        displayName: args.displayName,
+        displayName,
         summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : undefined,
         ownerUserId: user._id,
         tags: {},
@@ -550,7 +554,7 @@ export const publish = mutation({
 
     await ctx.db.patch(skill._id, {
       latestVersionId: versionId,
-      displayName: args.displayName,
+      displayName,
       summary: typeof parsed.frontmatter.description === "string" ? parsed.frontmatter.description : skill.summary,
       tags: currentTags,
       stats: { ...skill.stats, versions: skill.stats.versions + 1 },


### PR DESCRIPTION
## Summary
- Made `displayName` optional in publish args for all 4 entity types
- Added `resolveDisplayName()` helper: provided value → existing value → title-cased slug (e.g. `github-issues` → `Github Issues`)
- Updated HTTP API handlers to no longer require `displayName` in requests
- Updated CLI to title-case slug fallback instead of using raw slug

## Test plan
- [x] All 51 publishValidation tests pass
- [x] All 249 CLI tests pass
- [x] Frontend build passes
- [ ] Publish a skill without `displayName` — should auto-generate from slug
- [ ] Update a skill without `displayName` — should keep existing name
- [ ] Publish with explicit `displayName` — should use provided value

🤖 Generated with [Claude Code](https://claude.com/claude-code)