### PR TITLE
Add HTTP endpoint for CLI download tracking

### DIFF
--- a/cli/src/strawhub/client.py
+++ b/cli/src/strawhub/client.py
@@ -215,6 +215,18 @@ class StrawHubClient:
         resp = self._request("POST", "/api/v1/memories", data=form_data, files=files)
         return self._handle_response(resp)
 
+    # ── Downloads ──────────────────────────────────────────────────────────────
+
+    def track_download(self, kind: str, slug: str, version: str | None = None) -> None:
+        """Track a download event. Fire-and-forget — errors are silently ignored."""
+        body: dict = {"kind": kind, "slug": slug}
+        if version:
+            body["version"] = version
+        try:
+            self._request("POST", "/api/v1/downloads", json=body)
+        except Exception:
+            pass  # Best-effort, don't fail installs over tracking
+
     # ── Stars ─────────────────────────────────────────────────────────────────
 
     def toggle_star(self, slug: str, kind: str) -> dict:

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as files from "../files.js";
 import type * as http from "../http.js";
 import type * as httpApiV1_adminV1 from "../httpApiV1/adminV1.js";
 import type * as httpApiV1_agentsV1 from "../httpApiV1/agentsV1.js";
+import type * as httpApiV1_downloadsV1 from "../httpApiV1/downloadsV1.js";
 import type * as httpApiV1_memoriesV1 from "../httpApiV1/memoriesV1.js";
 import type * as httpApiV1_rolesV1 from "../httpApiV1/rolesV1.js";
 import type * as httpApiV1_searchV1 from "../httpApiV1/searchV1.js";
@@ -68,6 +69,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "httpApiV1/adminV1": typeof httpApiV1_adminV1;
   "httpApiV1/agentsV1": typeof httpApiV1_agentsV1;
+  "httpApiV1/downloadsV1": typeof httpApiV1_downloadsV1;
   "httpApiV1/memoriesV1": typeof httpApiV1_memoriesV1;
   "httpApiV1/rolesV1": typeof httpApiV1_rolesV1;
   "httpApiV1/searchV1": typeof httpApiV1_searchV1;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -9,6 +9,7 @@ import { searchAll } from "./httpApiV1/searchV1";
 import { whoami } from "./httpApiV1/whoamiV1";
 
 import { toggleStar } from "./httpApiV1/starsV1";
+import { trackDownload } from "./httpApiV1/downloadsV1";
 import { setUserRole, banUser } from "./httpApiV1/adminV1";
 import { corsResponse } from "./httpApiV1/shared";
 
@@ -101,6 +102,10 @@ http.route({ pathPrefix: "/api/v1/memories/", method: "OPTIONS", handler: corsHa
 // ── Stars ───────────────────────────────────────────────────────────────────
 http.route({ path: "/api/v1/stars/toggle", method: "POST", handler: toggleStar });
 http.route({ path: "/api/v1/stars/toggle", method: "OPTIONS", handler: corsHandler });
+
+// ── Downloads ──────────────────────────────────────────────────────────────
+http.route({ path: "/api/v1/downloads", method: "POST", handler: trackDownload });
+http.route({ path: "/api/v1/downloads", method: "OPTIONS", handler: corsHandler });
 
 // ── Search ──────────────────────────────────────────────────────────────────
 http.route({ path: "/api/v1/search", method: "GET", handler: searchAll });

--- a/convex/httpApiV1/downloadsV1.ts
+++ b/convex/httpApiV1/downloadsV1.ts
@@ -1,0 +1,38 @@
+import { httpAction } from "../_generated/server";
+import { api } from "../_generated/api";
+import { jsonResponse, errorResponse, corsResponse } from "./shared";
+
+/**
+ * POST /api/v1/downloads
+ * Body: { "kind": "skill"|"role"|"agent"|"memory", "slug": "...", "version": "..." }
+ *
+ * No auth required — download tracking is public (like npm).
+ */
+export const trackDownload = httpAction(async (ctx, request) => {
+  if (request.method === "OPTIONS") return corsResponse();
+
+  let body: { kind?: string; slug?: string; version?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { kind, slug, version } = body;
+  if (!kind || !slug) {
+    return errorResponse("kind and slug are required", 400);
+  }
+
+  const validKinds = ["skill", "role", "agent", "memory"];
+  if (!validKinds.includes(kind)) {
+    return errorResponse(`kind must be one of: ${validKinds.join(", ")}`, 400);
+  }
+
+  await ctx.runMutation(api.downloads.trackDownload, {
+    targetKind: kind as "skill" | "role" | "agent" | "memory",
+    slug,
+    version,
+  });
+
+  return jsonResponse({ ok: true });
+});

--- a/convex/statEvents.ts
+++ b/convex/statEvents.ts
@@ -44,7 +44,7 @@ export const flushStatEvents = internalMutation({
             ...(target as any).stats,
             downloads: (target as any).stats.downloads + delta,
           },
-        });
+        } as any);
       }
     }
 
@@ -54,7 +54,7 @@ export const flushStatEvents = internalMutation({
       if (ver) {
         await ctx.db.patch(ver._id, {
           downloads: ((ver as any).downloads ?? 0) + delta,
-        });
+        } as any);
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/downloads` HTTP endpoint so the CLI can track installs via the REST API
- Adds `track_download()` method to the Python client (fire-and-forget, errors silently ignored)
- Minor type cast fix in `statEvents.ts` flush logic

## Test plan
- [ ] Deploy to Convex and verify `POST /api/v1/downloads` accepts `{ kind, slug, version }`
- [ ] Run `strawhub install <slug>` and confirm a `statEvent` is created
- [ ] Wait for cron flush and verify download count increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)