### PR TITLE
Deduplicate download counts per user

### DIFF
--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -6,12 +6,17 @@ import { mutation } from "./_generated/server";
  * A cron job (every 15 min) flushes accumulated events into the target
  * document's stats, preventing thundering-herd query invalidation on
  * popular items.
+ *
+ * Authenticated downloads are deduplicated per user+target+version:
+ * only the first download of a given version by a given user is counted.
+ * Anonymous downloads are always counted (like npm/PyPI).
  */
 export const trackDownload = mutation({
   args: {
     targetKind: v.union(v.literal("skill"), v.literal("role"), v.literal("agent"), v.literal("memory")),
     slug: v.string(),
     version: v.optional(v.string()),
+    userId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const table = args.targetKind === "skill" ? "skills"
@@ -62,11 +67,26 @@ export const trackDownload = mutation({
       }
     }
 
+    // Deduplicate: skip if this user already downloaded this target+version
+    if (args.userId) {
+      const existing = await ctx.db
+        .query("statEvents")
+        .withIndex("by_user_target_version", (q) =>
+          q
+            .eq("userId", args.userId!)
+            .eq("targetId", target._id)
+            .eq("versionId", versionId),
+        )
+        .first();
+      if (existing) return;
+    }
+
     await ctx.db.insert("statEvents", {
       targetKind: args.targetKind,
       targetId: target._id,
       event: "download",
       versionId,
+      userId: args.userId,
       createdAt: Date.now(),
     });
   },

--- a/convex/httpApiV1/downloadsV1.ts
+++ b/convex/httpApiV1/downloadsV1.ts
@@ -1,12 +1,13 @@
 import { httpAction } from "../_generated/server";
 import { api } from "../_generated/api";
-import { jsonResponse, errorResponse, corsResponse } from "./shared";
+import { jsonResponse, errorResponse, corsResponse, extractBearerToken, hashToken } from "./shared";
+import { internal } from "../_generated/api";
 
 /**
  * POST /api/v1/downloads
  * Body: { "kind": "skill"|"role"|"agent"|"memory", "slug": "...", "version": "..." }
  *
- * No auth required — download tracking is public (like npm).
+ * Auth is optional — authenticated requests are deduplicated per user.
  */
 export const trackDownload = httpAction(async (ctx, request) => {
   if (request.method === "OPTIONS") return corsResponse();
@@ -28,10 +29,26 @@ export const trackDownload = httpAction(async (ctx, request) => {
     return errorResponse(`kind must be one of: ${validKinds.join(", ")}`, 400);
   }
 
+  // Optionally resolve user from auth token for per-user dedup
+  let userId: string | undefined;
+  const token = extractBearerToken(request);
+  if (token) {
+    try {
+      const tokenHash = await hashToken(token);
+      const apiToken = await ctx.runQuery(internal.apiTokens.getByHash, { tokenHash });
+      if (apiToken && !apiToken.revokedAt) {
+        userId = apiToken.userId;
+      }
+    } catch {
+      // Auth failure is fine — treat as anonymous
+    }
+  }
+
   await ctx.runMutation(api.downloads.trackDownload, {
     targetKind: kind as "skill" | "role" | "agent" | "memory",
     slug,
     version,
+    userId,
   });
 
   return jsonResponse({ ok: true });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -500,8 +500,11 @@ export default defineSchema({
     targetId: v.string(),
     event: v.union(v.literal("download")),
     versionId: v.optional(v.string()),
+    userId: v.optional(v.string()),
     createdAt: v.number(),
-  }).index("by_createdAt", ["createdAt"]),
+  })
+    .index("by_createdAt", ["createdAt"])
+    .index("by_user_target_version", ["userId", "targetId", "versionId"]),
 
   // ── Counters ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Resolves userId server-side from the auth token in the download tracking endpoint
- Deduplicates statEvents per user+target+version — only the first download by a user counts
- Anonymous downloads still count every time (same behavior as npm/PyPI)
- No client-side changes needed — the CLI already sends the auth token

## Changes
- `convex/schema.ts` — added optional `userId` field and `by_user_target_version` index to `statEvents`
- `convex/httpApiV1/downloadsV1.ts` — optionally resolves user from Bearer token (no auth failure on missing/invalid token)
- `convex/downloads.ts` — checks for existing statEvent before inserting when userId is present

## Test plan
- [ ] Authenticated user: `strawhub install skill X` twice → download count increments by 1, not 2
- [ ] Anonymous user (no token): downloads still count every time
- [ ] Invalid/revoked token: treated as anonymous, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)