### PR TITLE
Update docs to match current codebase

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,7 +47,7 @@ Four content types with parallel structure:
 
 Markdown instruction modules that agents load into context. Based on the [Agent Skills](https://agentskills.io/) open spec, extended with `metadata.strawpot` for dependencies and tool declarations.
 
-- **Files:** `SKILL.md` (required) + supporting text files (optional, up to 20 files, 512 KB each)
+- **Files:** `SKILL.md` (required) + supporting text files (optional, up to 100 files, 512 KB each)
 - **Dependencies:** flat list of other skill slugs
 - **Allowed file types:** `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 
@@ -63,7 +63,7 @@ Agent behavior definitions — instructions, default agent runtime, and dependen
 
 CLI wrapper binaries that translate StrawPot's protocol into native AI tool interfaces. Agents contain an `AGENT.md` frontmatter file plus compiled binaries per OS.
 
-- **Files:** `AGENT.md` (required) + binary files (up to 50 files, 10 MB each, 50 MB total)
+- **Files:** `AGENT.md` (required) + binary files (up to 100 files, 10 MB each, 50 MB total)
 - **Dependencies:** none (agents are standalone)
 - **Allowed file types:** any (binaries allowed)
 - **Unique fields:** `bin` (OS-specific binary paths), `params`, `tools`, `env`
@@ -72,7 +72,7 @@ CLI wrapper binaries that translate StrawPot's protocol into native AI tool inte
 
 Persistent knowledge banks that store context, patterns, and learned information across agent sessions.
 
-- **Files:** `MEMORY.md` (required) + supporting files (up to 50 files, 10 MB each, 50 MB total)
+- **Files:** `MEMORY.md` (required) + supporting files (up to 100 files, 10 MB each, 50 MB total)
 - **Dependencies:** none (memories are standalone)
 - **Allowed file types:** any (binaries allowed)
 
@@ -179,6 +179,8 @@ Skills, roles, agents, and memories have **separate slug namespaces**. A skill n
 | `reports` | Content moderation reports |
 | `apiTokens` | SHA-256 hashed Bearer tokens for CLI/API auth |
 | `auditLogs` | Moderation action trail |
+| `statEvents` | Event-sourced download tracking (flushed by cron into target stats) |
+| `counters` | Aggregated counters |
 | `rateLimits` | Per-IP/per-token rate limiting buckets |
 
 ### Versioning
@@ -212,7 +214,7 @@ Web UI also supports **GitHub import**: paste a repo URL, files are fetched via 
 
 ### Dependency Resolution
 
-**Skills** — client-side DFS. The CLI recursively fetches frontmatter for each dependency and builds the transitive list.
+**Skills** — server-side resolution via `GET /api/v1/skills/:slug/resolve`, or client-side DFS as fallback. The server recursively fetches frontmatter for each dependency and builds the transitive list.
 
 **Roles** — server-side topological sort via `GET /api/v1/roles/:slug/resolve`. The server walks both skill and role dependencies, detects cycles, and returns a sorted install order (leaves first). The `"*"` wildcard in the `roles` dependency list is filtered out by the CLI before install — it is not a real dependency but a runtime directive expanded by StrawPot.
 
@@ -238,10 +240,10 @@ Searches skills, roles, agents, and memories simultaneously. Falls back to text 
 ### Install (CLI)
 
 ```
-CLI → resolve dependencies → fetch files → extract to ~/.strawpot/{skills,roles,agents,memories}/{slug}-{version}/
+CLI → resolve dependencies → fetch files → extract to ~/.strawpot/{skills,roles,agents,memories}/{slug}/
 ```
 
-Install state tracked via lockfile at `.strawpot/strawpot.lock`. After installation, declared system tools are checked — missing tools trigger OS-specific install commands (with user confirmation).
+Install state tracked via lockfile at `.strawpot/strawpot.lock`. The installed version is stored in a `.version` file within each package directory. After installation, declared system tools are checked — missing tools trigger OS-specific install commands (with user confirmation).
 
 ## Authentication & Authorization
 
@@ -299,7 +301,9 @@ GET    /api/v1/search?q=&kind=     Hybrid search
 GET    /api/v1/whoami              Current user info
 POST   /api/v1/stars/toggle        Toggle star (auth)
 POST   /api/v1/admin/set-role      Set user role (admin)
+POST   /api/v1/downloads           Track download event (public)
 POST   /api/v1/admin/ban-user      Ban/unban user (admin)
+POST   /api/v1/skills/:slug/claim  Claim skill ownership (admin)
 ```
 
 ## Directory Structure
@@ -358,5 +362,11 @@ strawhub/
 **Separate slug namespaces** — Skills, roles, agents, and memories can share the same slug. Keeps the content types independent and avoids naming conflicts across different concerns.
 
 **SHA-256 token hashing** — API tokens are hashed before storage. Raw token shown once at creation. Prevents token exposure from database breaches.
+
+**Event-sourced download tracking** — Downloads are tracked by inserting lightweight events into `statEvents`. A cron job flushes accumulated events every 15 minutes, batch-patching target stats. This prevents thundering-herd query invalidation on popular items. Authenticated downloads are deduplicated per user+target+version; anonymous downloads are always counted.
+
+**Vercel Edge Middleware for API routing** — A middleware (`middleware.ts`) rewrites `/api/v1/*` requests to the Convex site URL, using `VITE_CONVEX_SITE_URL` with a hardcoded production fallback. This enables preview deployments to route API calls to their own Convex backend.
+
+**Optional display name with auto-generation** — `displayName` is optional on publish. If not provided, it falls back to the existing display name (on updates) or is auto-generated by title-casing the slug (e.g., `code-review` → `Code Review`).
 
 **Hybrid search over pure vector** — Combining vector similarity with lexical matching and popularity boost produces better results than any single signal alone. Gracefully degrades when embeddings are unavailable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ Embeddings are generated at publish time.
 ### Install (CLI)
 
 Resolves latest version via `GET /api/v1/skills/:slug` or `GET /api/v1/roles/:slug`.
-Downloads file content, extracts into `.strawpot/skills/<slug>-<version>/` or `.strawpot/roles/<slug>-<version>/`.
+Downloads file content, extracts into `.strawpot/skills/<slug>/` or `.strawpot/roles/<slug>/`. The installed version is tracked in a `.version` file within each package directory.
 
 **Skill dependencies** are resolved client-side: the CLI recursively fetches frontmatter and performs a DFS to build a transitive dependency list.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -425,21 +425,21 @@ Resolution checks local scope first, then global. Returns the highest installed 
   "slug": "implementer",
   "kind": "role",
   "version": "1.0.0",
-  "path": "/absolute/path/.strawpot/roles/implementer-1.0.0",
+  "path": "/absolute/path/.strawpot/roles/implementer",
   "source": "local",
   "dependencies": [
     {
       "slug": "git-workflow",
       "kind": "skill",
       "version": "1.2.0",
-      "path": "/absolute/path/.strawpot/skills/git-workflow-1.2.0",
+      "path": "/absolute/path/.strawpot/skills/git-workflow",
       "source": "local"
     },
     {
       "slug": "code-review",
       "kind": "skill",
       "version": "2.1.0",
-      "path": "/absolute/path/.strawpot/skills/code-review-2.1.0",
+      "path": "/absolute/path/.strawpot/skills/code-review",
       "source": "global"
     }
   ]
@@ -673,14 +673,17 @@ See [Project File documentation](project-file.md) for full details on workflows 
 ├── strawpot.toml              # Project file (human-editable, committed to VCS)
 └── .strawpot/                 # Local package store
     ├── skills/
-    │   ├── code-review-2.1.0/
+    │   ├── code-review/
     │   │   ├── SKILL.md
+    │   │   ├── .version
     │   │   └── ...
-    │   └── git-workflow-1.2.0/
-    │       └── SKILL.md
+    │   └── git-workflow/
+    │       ├── SKILL.md
+    │       └── .version
     ├── roles/
-    │   └── implementer-1.0.0/
-    │       └── ROLE.md
+    │   └── implementer/
+    │       ├── ROLE.md
+    │       └── .version
     └── strawpot.lock          # Auto-generated lockfile (JSON)
 ```
 

--- a/docs/content-format.md
+++ b/docs/content-format.md
@@ -144,7 +144,7 @@ Agent instructions...
 
 ### Agent file constraints
 
-- Up to 50 files, 10 MB each, 50 MB total
+- Up to 100 files, 10 MB each, 50 MB total
 - Supports binary files (compiled executables)
 
 ## Memories
@@ -177,7 +177,7 @@ Memory contents for the agent...
 
 ### Memory file constraints
 
-- Up to 50 files, 10 MB each, 50 MB total
+- Up to 100 files, 10 MB each, 50 MB total
 - Supports binary files
 
 ## System Tools
@@ -209,12 +209,12 @@ During `strawhub install` / `strawhub update`, the CLI checks if each declared t
 ## File Constraints
 
 ### Skills and Roles
-- Up to 20 files per package, 512 KB each
+- Up to 100 files per package, 512 KB each
 - Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 - Roles must contain exactly one file named `ROLE.md`
 
 ### Agents and Memories
-- Up to 50 files per package, 10 MB each, 50 MB total
+- Up to 100 files per package, 10 MB each, 50 MB total
 - Supports binary files (compiled executables, data files)
 
 ## Naming

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -66,7 +66,7 @@ payload: { slug, displayName, version, changelog, dependencies?, customTags?, fi
 
 The `dependencies` field is optional JSON: `{"skills": ["security-baseline", "git-workflow==1.0.0"]}`. Skills can only depend on other skills. If omitted, dependencies are read from `metadata.strawpot.dependencies` in the SKILL.md frontmatter.
 
-File constraints: up to 20 files, 512 KB each. Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`.
+File constraints: up to 100 files, 512 KB each. Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`.
 
 Additional constraints:
 - Slug must be unique within skills.
@@ -219,7 +219,7 @@ Content-Type: multipart/form-data
 payload: { slug, displayName, version, changelog, customTags?, files[] }
 ```
 
-File constraints: up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+File constraints: up to 100 files, 10 MB each, 50 MB total. Supports binary files.
 
 ### Get Agent Detail
 
@@ -271,7 +271,7 @@ Content-Type: multipart/form-data
 payload: { slug, displayName, version, changelog, customTags?, files[] }
 ```
 
-File constraints: up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+File constraints: up to 100 files, 10 MB each, 50 MB total. Supports binary files.
 
 ### Get Memory Detail
 
@@ -313,6 +313,21 @@ Content-Type: application/json
 ```
 
 Toggles the star status for the authenticated user. Returns `{ "starred": true }` or `{ "starred": false }`.
+
+---
+
+## Downloads
+
+### Track Download
+
+```
+POST /api/v1/downloads
+Content-Type: application/json
+
+{ "kind": "skill|role|agent|memory", "slug": "...", "version": "..." }
+```
+
+No auth required — download tracking is public (like npm). The `version` field is optional. Downloads are tracked via event sourcing: events are inserted into `statEvents` and flushed into target stats every 15 minutes by a cron job.
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -107,7 +107,7 @@ name: project-context
 description: "Persistent project context and conventions"
 ```
 
-**File constraints:** Up to 50 files, 10 MB each, 50 MB total. Supports binary files.
+**File constraints:** Up to 100 files, 10 MB each, 50 MB total. Supports binary files.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Fix file limits across all docs (20/50 → 100 for all content types)
- Fix install paths from `{slug}-{version}/` to `{slug}/` with `.version` file
- Add missing data model tables (`statEvents`, `counters`) to DESIGN.md
- Add missing API endpoints (`POST /api/v1/downloads`, `POST /api/v1/skills/:slug/claim`)
- Add design decisions: event-sourced download tracking, Vercel middleware, display name auto-generation
- Add Downloads section to HTTP API docs

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Cross-reference changes against actual codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)