### PR TITLE
Add tests for search, uninstall, update, install, and download tracking

### DIFF
--- a/cli/tests/test_client.py
+++ b/cli/tests/test_client.py
@@ -181,6 +181,32 @@ class TestDeletePackage:
         client.delete_role.assert_called_once_with("x")
 
 
+class TestTrackDownload:
+    def test_fire_and_forget_swallows_errors(self, client):
+        """track_download silently ignores errors — never raises."""
+        client._request = MagicMock(side_effect=Exception("network error"))
+        # Should not raise
+        client.track_download("skill", "my-skill", version="1.0.0")
+
+    def test_sends_correct_payload(self, client):
+        client._request = MagicMock(return_value={"ok": True})
+        client.track_download("agent", "my-agent", version="2.0.0")
+        client._request.assert_called_once_with(
+            "POST",
+            "/api/v1/downloads",
+            json={"kind": "agent", "slug": "my-agent", "version": "2.0.0"},
+        )
+
+    def test_omits_version_when_none(self, client):
+        client._request = MagicMock(return_value={"ok": True})
+        client.track_download("skill", "my-skill")
+        client._request.assert_called_once_with(
+            "POST",
+            "/api/v1/downloads",
+            json={"kind": "skill", "slug": "my-skill"},
+        )
+
+
 class TestContextManager:
     def test_context_manager(self):
         with patch("strawhub.client.get_api_url", return_value="https://fake.test"):

--- a/cli/tests/test_install.py
+++ b/cli/tests/test_install.py
@@ -1,8 +1,14 @@
 """Tests for strawhub.commands.install helpers."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from strawhub.commands.install import _resolve_deps
+import pytest
+
+from strawhub.commands.install import (
+    _resolve_deps,
+    _slug_installed_in_scope,
+    _download_package,
+)
 
 
 class TestResolveDepsWildcard:
@@ -46,3 +52,81 @@ class TestResolveDepsWildcard:
         client.resolve_skill_deps.assert_called_once_with("my-skill")
         assert len(result) == 2
         assert result[0]["slug"] == "git-workflow"
+
+    def test_agents_have_no_deps(self):
+        """Agents are standalone — resolve returns empty list."""
+        client = MagicMock()
+        result = _resolve_deps(client, "agent", "my-agent", {})
+        assert result == []
+        client.resolve_skill_deps.assert_not_called()
+        client.resolve_role_deps.assert_not_called()
+
+    def test_memories_have_no_deps(self):
+        """Memories are standalone — resolve returns empty list."""
+        client = MagicMock()
+        result = _resolve_deps(client, "memory", "my-mem", {})
+        assert result == []
+
+
+class TestSlugInstalledInScope:
+    def test_returns_version_when_installed(self, tmp_path):
+        root = tmp_path
+        pkg_dir = root / "skills" / "foo"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / ".version").write_text("1.2.3\n")
+        result = _slug_installed_in_scope(root, "skill", "foo")
+        assert result == "1.2.3"
+
+    def test_returns_none_when_not_installed(self, tmp_path):
+        result = _slug_installed_in_scope(tmp_path, "skill", "nonexistent")
+        assert result is None
+
+
+class TestDownloadPackage:
+    def test_writes_files_and_version(self, tmp_path):
+        """Downloads files, writes them to disk, and creates .version marker."""
+        client = MagicMock()
+        client.get_info.return_value = (
+            "skill",
+            {
+                "latestVersion": {
+                    "version": "1.0.0",
+                    "files": [
+                        {"path": "SKILL.md"},
+                        {"path": "examples/demo.md"},
+                    ],
+                },
+            },
+        )
+        client.get_skill_file.side_effect = [
+            "# Skill content",
+            "# Demo",
+        ]
+        client.track_download = MagicMock()
+
+        _download_package(client, "skill", "my-skill", "1.0.0", tmp_path)
+
+        assert (tmp_path / "skills" / "my-skill" / "SKILL.md").read_text() == "# Skill content"
+        assert (tmp_path / "skills" / "my-skill" / "examples" / "demo.md").read_text() == "# Demo"
+        assert (tmp_path / "skills" / "my-skill" / ".version").read_text().strip() == "1.0.0"
+        client.track_download.assert_called_once_with("skill", "my-skill", version="1.0.0")
+
+    def test_agent_uses_binary_download(self, tmp_path):
+        """Agents use get_agent_file (binary) instead of get_skill_file (text)."""
+        client = MagicMock()
+        client.get_info.return_value = (
+            "agent",
+            {
+                "latestVersion": {
+                    "version": "0.1.0",
+                    "files": [{"path": "AGENT.md"}],
+                },
+            },
+        )
+        client.get_agent_file.return_value = b"binary content"
+        client.track_download = MagicMock()
+
+        _download_package(client, "agent", "my-agent", "0.1.0", tmp_path)
+
+        assert (tmp_path / "agents" / "my-agent" / "AGENT.md").read_bytes() == b"binary content"
+        client.get_agent_file.assert_called_once()

--- a/cli/tests/test_uninstall.py
+++ b/cli/tests/test_uninstall.py
@@ -1,0 +1,203 @@
+"""Tests for strawhub.commands.uninstall."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from strawhub.commands.uninstall import _find_targets, _uninstall_impl
+from strawhub.lockfile import Lockfile, PackageRef
+from strawhub.paths import get_package_dir
+
+
+@pytest.fixture
+def setup_installed(tmp_path):
+    """Create a .strawpot directory with installed packages and a lockfile."""
+    root = tmp_path / ".strawpot"
+    (root / "skills").mkdir(parents=True)
+    (root / "roles").mkdir(parents=True)
+
+    def _setup(packages, direct_installs=None, dependents=None):
+        lockfile = Lockfile(path=root / "strawpot.lock")
+        for pkg in packages:
+            ref = PackageRef(**pkg)
+            pkg_dir = get_package_dir(root, pkg["kind"], pkg["slug"])
+            pkg_dir.mkdir(parents=True, exist_ok=True)
+            md_name = f"{pkg['kind'].upper()}.md"
+            (pkg_dir / md_name).write_text(f"---\nname: {pkg['slug']}\n---\n")
+            (pkg_dir / ".version").write_text(pkg["version"] + "\n")
+            lockfile.add_package(ref)
+
+        for ref_dict in (direct_installs or []):
+            lockfile.add_direct_install(PackageRef(**ref_dict))
+
+        if dependents:
+            for dep_key, parent_ref_dict in dependents:
+                parent_ref = PackageRef(**parent_ref_dict)
+                pkg_dict = next(
+                    p for p in packages
+                    if f"{p['kind']}:{p['slug']}" == dep_key
+                )
+                dep_ref = PackageRef(**pkg_dict)
+                lockfile.add_package(dep_ref, dependent=parent_ref)
+
+        lockfile.save()
+        return root, lockfile
+
+    return _setup
+
+
+class TestFindTargets:
+    def test_finds_matching_direct_install(self):
+        lockfile = Lockfile.__new__(Lockfile)
+        lockfile.direct_installs = [
+            PackageRef(kind="skill", slug="foo", version="1.0.0"),
+            PackageRef(kind="skill", slug="bar", version="2.0.0"),
+        ]
+        targets = _find_targets(lockfile, "foo", "skill", None)
+        assert len(targets) == 1
+        assert targets[0].slug == "foo"
+
+    def test_filters_by_kind(self):
+        lockfile = Lockfile.__new__(Lockfile)
+        lockfile.direct_installs = [
+            PackageRef(kind="skill", slug="foo", version="1.0.0"),
+            PackageRef(kind="role", slug="foo", version="1.0.0"),
+        ]
+        targets = _find_targets(lockfile, "foo", "role", None)
+        assert len(targets) == 1
+        assert targets[0].kind == "role"
+
+    def test_filters_by_version(self):
+        lockfile = Lockfile.__new__(Lockfile)
+        lockfile.direct_installs = [
+            PackageRef(kind="skill", slug="foo", version="1.0.0"),
+        ]
+        targets = _find_targets(lockfile, "foo", "skill", "2.0.0")
+        assert len(targets) == 0
+
+    def test_returns_empty_for_no_match(self):
+        lockfile = Lockfile.__new__(Lockfile)
+        lockfile.direct_installs = [
+            PackageRef(kind="skill", slug="bar", version="1.0.0"),
+        ]
+        targets = _find_targets(lockfile, "foo", "skill", None)
+        assert len(targets) == 0
+
+
+class TestUninstallImpl:
+    @patch("strawhub.commands.uninstall.get_root")
+    @patch("strawhub.commands.uninstall.get_lockfile_path")
+    def test_removes_package_from_disk_and_lockfile(
+        self, mock_lockfile_path, mock_get_root, setup_installed
+    ):
+        packages = [
+            {"kind": "skill", "slug": "my-skill", "version": "1.0.0"},
+        ]
+        root, _ = setup_installed(
+            packages, direct_installs=packages
+        )
+        mock_get_root.return_value = root
+        mock_lockfile_path.return_value = root / "strawpot.lock"
+
+        _uninstall_impl("my-skill", kind="skill", ver=None, is_global=False)
+
+        pkg_dir = get_package_dir(root, "skill", "my-skill")
+        assert not pkg_dir.exists()
+
+        lockfile = Lockfile.load(root / "strawpot.lock")
+        assert len(lockfile.packages) == 0
+        assert len(lockfile.direct_installs) == 0
+
+    @patch("strawhub.commands.uninstall.get_root")
+    @patch("strawhub.commands.uninstall.get_lockfile_path")
+    def test_error_when_not_direct_install(
+        self, mock_lockfile_path, mock_get_root, setup_installed
+    ):
+        packages = [
+            {"kind": "skill", "slug": "dep-skill", "version": "1.0.0"},
+        ]
+        # Package exists but is NOT a direct install
+        root, _ = setup_installed(packages, direct_installs=[])
+        mock_get_root.return_value = root
+        mock_lockfile_path.return_value = root / "strawpot.lock"
+
+        with pytest.raises(SystemExit):
+            _uninstall_impl("dep-skill", kind="skill", ver=None, is_global=False)
+
+    @patch("strawhub.commands.uninstall.get_root")
+    @patch("strawhub.commands.uninstall.get_lockfile_path")
+    def test_error_when_lockfile_empty(
+        self, mock_lockfile_path, mock_get_root, setup_installed
+    ):
+        root, _ = setup_installed([], direct_installs=[])
+        mock_get_root.return_value = root
+        mock_lockfile_path.return_value = root / "strawpot.lock"
+
+        with pytest.raises(SystemExit):
+            _uninstall_impl("anything", kind="skill", ver=None, is_global=False)
+
+    @patch("strawhub.commands.uninstall.get_root")
+    @patch("strawhub.commands.uninstall.get_lockfile_path")
+    def test_orphan_deps_removed(
+        self, mock_lockfile_path, mock_get_root, setup_installed
+    ):
+        """When removing a package, its orphaned dependencies are also cleaned up."""
+        parent = {"kind": "skill", "slug": "parent", "version": "1.0.0"}
+        child = {"kind": "skill", "slug": "child", "version": "1.0.0"}
+
+        root, _ = setup_installed(
+            [parent, child],
+            direct_installs=[parent],
+            dependents=[("skill:child", parent)],
+        )
+        mock_get_root.return_value = root
+        mock_lockfile_path.return_value = root / "strawpot.lock"
+
+        _uninstall_impl("parent", kind="skill", ver=None, is_global=False)
+
+        # Both parent and orphaned child should be removed
+        assert not get_package_dir(root, "skill", "parent").exists()
+        assert not get_package_dir(root, "skill", "child").exists()
+
+        lockfile = Lockfile.load(root / "strawpot.lock")
+        assert len(lockfile.packages) == 0
+
+    @patch("strawhub.commands.uninstall.get_root")
+    @patch("strawhub.commands.uninstall.get_lockfile_path")
+    def test_shared_dep_not_removed(
+        self, mock_lockfile_path, mock_get_root, setup_installed
+    ):
+        """A dependency shared by another direct install is NOT orphaned."""
+        parent1 = {"kind": "skill", "slug": "parent1", "version": "1.0.0"}
+        parent2 = {"kind": "skill", "slug": "parent2", "version": "1.0.0"}
+        shared = {"kind": "skill", "slug": "shared", "version": "1.0.0"}
+
+        root, _ = setup_installed(
+            [parent1, parent2, shared],
+            direct_installs=[parent1, parent2],
+            dependents=[
+                ("skill:shared", parent1),
+                ("skill:shared", parent2),
+            ],
+        )
+        mock_get_root.return_value = root
+        mock_lockfile_path.return_value = root / "strawpot.lock"
+
+        _uninstall_impl("parent1", kind="skill", ver=None, is_global=False)
+
+        # parent1 removed, but shared dep still needed by parent2
+        assert not get_package_dir(root, "skill", "parent1").exists()
+        assert get_package_dir(root, "skill", "shared").exists()
+
+    def test_root_and_global_conflict(self):
+        """--root and --global cannot be used together."""
+        with patch("strawhub.paths._local_root_override", "/tmp/x"):
+            with pytest.raises(SystemExit):
+                _uninstall_impl("x", kind="skill", ver=None, is_global=True)
+
+    def test_save_and_global_conflict(self):
+        """--save and --global cannot be used together."""
+        with pytest.raises(SystemExit):
+            _uninstall_impl("x", kind="skill", ver=None, is_global=True, save=True)

--- a/cli/tests/test_update.py
+++ b/cli/tests/test_update.py
@@ -1,0 +1,96 @@
+"""Tests for strawhub.commands.update."""
+
+from unittest.mock import patch, MagicMock, call
+
+import pytest
+
+from strawhub.commands.update import _update_all_impl, _update_one_impl
+
+
+class TestUpdateOneImpl:
+    @patch("strawhub.commands.update._install_impl")
+    def test_calls_install_with_update_flag(self, mock_install):
+        _update_one_impl("my-skill", kind="skill", is_global=False)
+        mock_install.assert_called_once_with(
+            "my-skill",
+            kind="skill",
+            is_global=False,
+            skip_tools=False,
+            yes=False,
+            update=True,
+        )
+
+    @patch("strawhub.commands.update._install_impl")
+    def test_passes_skip_tools_and_yes(self, mock_install):
+        _update_one_impl(
+            "my-skill", kind="skill", is_global=False, skip_tools=True, yes=True
+        )
+        mock_install.assert_called_once_with(
+            "my-skill",
+            kind="skill",
+            is_global=False,
+            skip_tools=True,
+            yes=True,
+            update=True,
+        )
+
+    def test_root_and_global_conflict(self):
+        with patch("strawhub.paths._local_root_override", "/tmp/x"):
+            with pytest.raises(SystemExit):
+                _update_one_impl("x", kind="skill", is_global=True)
+
+    def test_save_and_global_conflict(self):
+        with pytest.raises(SystemExit):
+            _update_one_impl("x", kind="skill", is_global=True, save=True)
+
+
+class TestUpdateAllImpl:
+    @patch("strawhub.commands.update._install_impl")
+    @patch("strawhub.commands.update.Lockfile")
+    @patch("strawhub.commands.update.get_lockfile_path")
+    @patch("strawhub.commands.update.get_root")
+    def test_updates_all_direct_installs(
+        self, mock_root, mock_lf_path, mock_lockfile_cls, mock_install, tmp_path
+    ):
+        from strawhub.lockfile import PackageRef
+
+        mock_root.return_value = tmp_path
+        mock_lf_path.return_value = tmp_path / "strawpot.lock"
+
+        lockfile = MagicMock()
+        lockfile.direct_installs = [
+            PackageRef(kind="skill", slug="foo", version="1.0.0"),
+            PackageRef(kind="role", slug="bar", version="2.0.0"),
+        ]
+        mock_lockfile_cls.load.return_value = lockfile
+
+        _update_all_impl(is_global=False)
+
+        assert mock_install.call_count == 2
+        mock_install.assert_any_call(
+            "foo", kind="skill", is_global=False, skip_tools=False, yes=False, update=True,
+        )
+        mock_install.assert_any_call(
+            "bar", kind="role", is_global=False, skip_tools=False, yes=False, update=True,
+        )
+
+    @patch("strawhub.commands.update.Lockfile")
+    @patch("strawhub.commands.update.get_lockfile_path")
+    @patch("strawhub.commands.update.get_root")
+    def test_error_when_no_packages(
+        self, mock_root, mock_lf_path, mock_lockfile_cls, tmp_path
+    ):
+        mock_root.return_value = tmp_path
+        mock_lf_path.return_value = tmp_path / "strawpot.lock"
+
+        lockfile = MagicMock()
+        lockfile.direct_installs = []
+        mock_lockfile_cls.load.return_value = lockfile
+
+        with pytest.raises(SystemExit):
+            _update_all_impl(is_global=False)
+
+    def test_root_and_global_conflict(self):
+        with patch("strawhub.paths._local_root_override", "/tmp/x"):
+            with pytest.raises(SystemExit):
+                _update_all_impl(is_global=True)

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { tokenize, computeLexicalBoost } from "./search";
+
+describe("tokenize", () => {
+  it("splits on spaces", () => {
+    expect(tokenize("hello world")).toEqual(["hello", "world"]);
+  });
+
+  it("splits on hyphens", () => {
+    expect(tokenize("code-review")).toEqual(["code", "review"]);
+  });
+
+  it("splits on underscores", () => {
+    expect(tokenize("git_workflow")).toEqual(["git", "workflow"]);
+  });
+
+  it("splits on dots and slashes", () => {
+    expect(tokenize("src/lib.utils")).toEqual(["src", "lib", "utils"]);
+  });
+
+  it("lowercases input", () => {
+    expect(tokenize("Code-Review")).toEqual(["code", "review"]);
+  });
+
+  it("filters empty tokens", () => {
+    expect(tokenize("--double--dash--")).toEqual(["double", "dash"]);
+  });
+
+  it("handles empty string", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+
+  it("handles single word", () => {
+    expect(tokenize("testing")).toEqual(["testing"]);
+  });
+
+  it("splits on mixed delimiters", () => {
+    expect(tokenize("my-skill_v2.0/beta")).toEqual([
+      "my",
+      "skill",
+      "v2",
+      "0",
+      "beta",
+    ]);
+  });
+});
+
+describe("computeLexicalBoost", () => {
+  it("gives max boost for exact slug + name match", () => {
+    const tokens = tokenize("code review");
+    const boost = computeLexicalBoost(tokens, "code-review", "Code Review");
+    // "code": slug exact (1.4) + name exact (1.1)
+    // "review": slug exact (1.4) + name exact (1.1)
+    expect(boost).toBeCloseTo(5.0);
+  });
+
+  it("gives slug prefix boost when partial match", () => {
+    const tokens = tokenize("cod");
+    const boost = computeLexicalBoost(tokens, "code-review", "Code Review");
+    // "cod": slug prefix (0.8) + name prefix (0.6)
+    expect(boost).toBeCloseTo(1.4);
+  });
+
+  it("returns 0 for no match", () => {
+    const tokens = tokenize("python");
+    const boost = computeLexicalBoost(tokens, "code-review", "Code Review");
+    expect(boost).toBe(0);
+  });
+
+  it("handles slug match but no name match", () => {
+    const tokens = tokenize("git");
+    const boost = computeLexicalBoost(
+      tokens,
+      "git-workflow",
+      "Source Control Flow",
+    );
+    // "git": slug exact (1.4), no name match (0)
+    expect(boost).toBeCloseTo(1.4);
+  });
+
+  it("handles name match but no slug match", () => {
+    const tokens = tokenize("source");
+    const boost = computeLexicalBoost(
+      tokens,
+      "git-workflow",
+      "Source Control",
+    );
+    // "source": no slug match, name exact (1.1)
+    expect(boost).toBeCloseTo(1.1);
+  });
+
+  it("accumulates boost for multiple matching tokens", () => {
+    const tokens = tokenize("git workflow");
+    const boost = computeLexicalBoost(tokens, "git-workflow", "Git Workflow");
+    // "git": slug exact (1.4) + name exact (1.1)
+    // "workflow": slug exact (1.4) + name exact (1.1)
+    expect(boost).toBeCloseTo(5.0);
+  });
+
+  it("prefix match scores lower than exact", () => {
+    const exact = computeLexicalBoost(
+      tokenize("code"),
+      "code-review",
+      "Other Name",
+    );
+    const prefix = computeLexicalBoost(
+      tokenize("cod"),
+      "code-review",
+      "Other Name",
+    );
+    expect(exact).toBeGreaterThan(prefix);
+  });
+
+  it("handles empty query tokens", () => {
+    const boost = computeLexicalBoost([], "code-review", "Code Review");
+    expect(boost).toBe(0);
+  });
+});
+
+describe("popularity boost formula", () => {
+  it("log(1) gives zero boost", () => {
+    const boost = Math.log(Math.max(0, 1)) * 0.08;
+    expect(boost).toBe(0);
+  });
+
+  it("higher downloads give higher boost", () => {
+    const low = Math.log(Math.max(10, 1)) * 0.08;
+    const high = Math.log(Math.max(1000, 1)) * 0.08;
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it("boost grows logarithmically (equal ratios add equal increments)", () => {
+    const d100 = Math.log(100) * 0.08;
+    const d1000 = Math.log(1000) * 0.08;
+    const d10000 = Math.log(10000) * 0.08;
+    const diff1 = d1000 - d100;
+    const diff2 = d10000 - d1000;
+    expect(diff1).toBeCloseTo(diff2, 5);
+  });
+});

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -127,14 +127,14 @@ interface SearchResult {
   score: number;
 }
 
-function tokenize(text: string): string[] {
+export function tokenize(text: string): string[] {
   return text
     .toLowerCase()
     .split(/[\s\-_./]+/)
     .filter((t) => t.length > 0);
 }
 
-function computeLexicalBoost(
+export function computeLexicalBoost(
   queryTokens: string[],
   slug: string,
   displayName: string,


### PR DESCRIPTION
## Summary
- Add 47 new tests covering critical gaps identified in test suite review
- **convex/search.test.ts** (20 tests): tokenize delimiter handling, computeLexicalBoost exact/prefix/mixed scoring, popularity boost formula
- **cli/tests/test_uninstall.py** (11 tests): _find_targets filtering, full uninstall workflow (disk + lockfile), orphan cascade, shared dep preservation, flag conflicts
- **cli/tests/test_update.py** (7 tests): update-one delegation, update-all iteration, empty package errors, flag conflicts
- **cli/tests/test_install.py** (6 new tests): agent/memory have no deps, _slug_installed_in_scope, _download_package file writing + version marker + binary agent
- **cli/tests/test_client.py** (3 new tests): track_download fire-and-forget error swallowing, payload correctness, optional version
- Export `tokenize` and `computeLexicalBoost` from search.ts for testability

## Test plan
- [x] All 242 Vitest tests pass
- [x] All 276 pytest CLI tests pass
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)