### PR TITLE
Pass userId to trackDownload for frontend dedup

### DIFF
--- a/src/routes/agents.$slug.tsx
+++ b/src/routes/agents.$slug.tsx
@@ -125,7 +125,7 @@ function AgentDetailPage() {
           {agent.latestVersion && agent.zipUrl && (
             <button
               onClick={async () => {
-                trackDownload({ targetKind: "agent", slug: agent.slug, version: agent.latestVersion!.version });
+                trackDownload({ targetKind: "agent", slug: agent.slug, version: agent.latestVersion!.version, userId: currentUser?._id });
                 const res = await fetch(agent.zipUrl!);
                 const blob = await res.blob();
                 const url = URL.createObjectURL(blob);
@@ -324,6 +324,7 @@ function AgentDetailPage() {
         latestVersionId={agent.latestVersionId}
         slug={agent.slug}
         trackDownload={trackDownload}
+        userId={currentUser?._id}
       />
 
       {/* Comments */}
@@ -428,6 +429,7 @@ function AgentDetailTabs({
   latestVersionId,
   slug,
   trackDownload,
+  userId,
 }: {
   files: Array<{ path: string; size: number; url: string | null }>;
   versions: Array<{
@@ -441,7 +443,8 @@ function AgentDetailTabs({
   loadMoreVersions: (numItems: number) => void;
   latestVersionId: string | undefined;
   slug: string;
-  trackDownload: (args: { targetKind: "skill" | "role" | "agent"; slug: string; version?: string }) => void;
+  trackDownload: (args: { targetKind: "skill" | "role" | "agent"; slug: string; version?: string; userId?: string }) => void;
+  userId?: string;
 }) {
   const [tab, setTab] = useState<"files" | "versions">("files");
 
@@ -585,7 +588,7 @@ function AgentDetailTabs({
                 {ver.zipUrl && (
                   <button
                     onClick={async () => {
-                      trackDownload({ targetKind: "agent", slug, version: ver.version });
+                      trackDownload({ targetKind: "agent", slug, version: ver.version, userId });
                       const res = await fetch(ver.zipUrl!);
                       const blob = await res.blob();
                       const url = URL.createObjectURL(blob);

--- a/src/routes/memories.$slug.tsx
+++ b/src/routes/memories.$slug.tsx
@@ -125,7 +125,7 @@ function MemoryDetailPage() {
           {memory.latestVersion && memory.zipUrl && (
             <button
               onClick={async () => {
-                trackDownload({ targetKind: "memory", slug: memory.slug, version: memory.latestVersion!.version });
+                trackDownload({ targetKind: "memory", slug: memory.slug, version: memory.latestVersion!.version, userId: currentUser?._id });
                 const res = await fetch(memory.zipUrl!);
                 const blob = await res.blob();
                 const url = URL.createObjectURL(blob);
@@ -324,6 +324,7 @@ function MemoryDetailPage() {
         latestVersionId={memory.latestVersionId}
         slug={memory.slug}
         trackDownload={trackDownload}
+        userId={currentUser?._id}
       />
 
       {/* Comments */}
@@ -428,6 +429,7 @@ function MemoryDetailTabs({
   latestVersionId,
   slug,
   trackDownload,
+  userId,
 }: {
   files: Array<{ path: string; size: number; url: string | null }>;
   versions: Array<{
@@ -441,7 +443,8 @@ function MemoryDetailTabs({
   loadMoreVersions: (numItems: number) => void;
   latestVersionId: string | undefined;
   slug: string;
-  trackDownload: (args: { targetKind: "skill" | "role" | "agent" | "memory"; slug: string; version?: string }) => void;
+  trackDownload: (args: { targetKind: "skill" | "role" | "agent" | "memory"; slug: string; version?: string; userId?: string }) => void;
+  userId?: string;
 }) {
   const [tab, setTab] = useState<"files" | "versions">("files");
 
@@ -585,7 +588,7 @@ function MemoryDetailTabs({
                 {ver.zipUrl && (
                   <button
                     onClick={async () => {
-                      trackDownload({ targetKind: "memory", slug, version: ver.version });
+                      trackDownload({ targetKind: "memory", slug, version: ver.version, userId });
                       const res = await fetch(ver.zipUrl!);
                       const blob = await res.blob();
                       const url = URL.createObjectURL(blob);

--- a/src/routes/roles.$slug.tsx
+++ b/src/routes/roles.$slug.tsx
@@ -126,7 +126,7 @@ function RoleDetailPage() {
           {role.latestVersion && role.zipUrl && (
             <button
               onClick={async () => {
-                trackDownload({ targetKind: "role", slug: role.slug, version: role.latestVersion!.version });
+                trackDownload({ targetKind: "role", slug: role.slug, version: role.latestVersion!.version, userId: currentUser?._id });
                 const res = await fetch(role.zipUrl!);
                 const blob = await res.blob();
                 const url = URL.createObjectURL(blob);
@@ -326,6 +326,7 @@ function RoleDetailPage() {
         slug={role.slug}
         targetKind="role"
         trackDownload={trackDownload}
+        userId={currentUser?._id}
       />
 
       {/* Comments */}
@@ -473,6 +474,7 @@ function DetailTabs({
   slug,
   targetKind,
   trackDownload,
+  userId,
 }: {
   files: Array<{ path: string; size: number; url: string | null }>;
   versions: Array<{
@@ -487,7 +489,8 @@ function DetailTabs({
   latestVersionId: string | undefined;
   slug: string;
   targetKind: "skill" | "role";
-  trackDownload: (args: { targetKind: "skill" | "role"; slug: string; version?: string }) => void;
+  trackDownload: (args: { targetKind: "skill" | "role"; slug: string; version?: string; userId?: string }) => void;
+  userId?: string;
 }) {
   const [tab, setTab] = useState<"files" | "versions">("files");
 
@@ -631,7 +634,7 @@ function DetailTabs({
                 {ver.zipUrl && (
                   <button
                     onClick={async () => {
-                      trackDownload({ targetKind, slug, version: ver.version });
+                      trackDownload({ targetKind, slug, version: ver.version, userId });
                       const res = await fetch(ver.zipUrl!);
                       const blob = await res.blob();
                       const url = URL.createObjectURL(blob);

--- a/src/routes/skills.$slug.tsx
+++ b/src/routes/skills.$slug.tsx
@@ -134,7 +134,7 @@ function SkillDetailPage() {
           {skill.latestVersion && skill.zipUrl && (
             <button
               onClick={async () => {
-                trackDownload({ targetKind: "skill", slug: skill.slug, version: skill.latestVersion!.version });
+                trackDownload({ targetKind: "skill", slug: skill.slug, version: skill.latestVersion!.version, userId: currentUser?._id });
                 const res = await fetch(skill.zipUrl!);
                 const blob = await res.blob();
                 const url = URL.createObjectURL(blob);
@@ -375,6 +375,7 @@ function SkillDetailPage() {
         slug={skill.slug}
         targetKind="skill"
         trackDownload={trackDownload}
+        userId={currentUser?._id}
       />
 
       {/* Comments */}
@@ -499,6 +500,7 @@ function DetailTabs({
   slug,
   targetKind,
   trackDownload,
+  userId,
 }: {
   files: Array<{ path: string; size: number; url: string | null }>;
   versions: Array<{
@@ -513,7 +515,8 @@ function DetailTabs({
   latestVersionId: string | undefined;
   slug: string;
   targetKind: "skill" | "role";
-  trackDownload: (args: { targetKind: "skill" | "role"; slug: string; version?: string }) => void;
+  trackDownload: (args: { targetKind: "skill" | "role"; slug: string; version?: string; userId?: string }) => void;
+  userId?: string;
 }) {
   const [tab, setTab] = useState<"files" | "versions">("files");
 
@@ -657,7 +660,7 @@ function DetailTabs({
                 {ver.zipUrl && (
                   <button
                     onClick={async () => {
-                      trackDownload({ targetKind, slug, version: ver.version });
+                      trackDownload({ targetKind, slug, version: ver.version, userId });
                       const res = await fetch(ver.zipUrl!);
                       const blob = await res.blob();
                       const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- Frontend `trackDownload` calls now pass `currentUser?._id` as `userId` when the user is logged in
- Enables per-user download deduplication on the frontend, matching the CLI behavior
- Anonymous (logged-out) downloads continue to be counted without dedup

## Test plan
- [ ] Log in and download a skill/role/agent/memory — verify only one `statEvents` row is created per version
- [ ] Download the same version again — verify no duplicate row
- [ ] Log out and download — verify the download is still counted (no userId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)