### PR TITLE
Fix critical scalability issues in backend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,40 @@ Run hourly or daily via cron.
 
 Reference: ClawHub's `reconcileSkillStarCounts` mutation.
 
+## Star Counter OCC Contention (High)
+
+Popular items receive many concurrent star/unstar operations, all patching the same `stats.stars` field on the skill/role/agent document. This causes Convex OCC (Optimistic Concurrency Control) retries under load.
+
+**Approach:** Move star counting to event-sourced pattern (like downloads already use `statEvents`). Instead of patching `stats.stars` inline during `toggleStar`, insert a `statEvents` row with `kind: "star"` or `kind: "unstar"`. The existing `flushStatEvents` cron (every 15 min) would aggregate and batch-patch counts, eliminating per-request write contention.
+
+**Risk:** Invasive change — requires modifying `toggleStar` mutation, `flushStatEvents` handler, and potentially the real-time star state UX (star count may lag up to 15 minutes).
+
+**Files:** `convex/stars.ts`, `convex/statEvents.ts`
+
+## Starred IDs Pagination Cap (Medium)
+
+Frontend listing pages load starred IDs with `initialNumItems: 1000`. Users who star 1000+ items won't see correct star indicators on listing pages.
+
+**Approach:** Either:
+1. Paginate through all starred IDs on the frontend (load more pages until `isDone`)
+2. Move the `isStarred` check to the backend `list` query (join against `stars` table using the current user)
+
+Option 2 is cleaner but requires passing the user context into list queries.
+
+**Files:** `src/routes/skills.index.tsx`, `src/routes/roles.index.tsx`, `src/routes/agents.index.tsx`, `src/routes/memories.index.tsx`, optionally `convex/skills.ts` (list query)
+
+## AuthAccounts Query Without Index (Medium)
+
+The `claimSkill` mutation queries `authAccounts` using `.filter()` (full table scan) to find a user's GitHub account. The `authAccounts` table is owned by `@convex-dev/auth` so custom indexes can't be added directly.
+
+**Approach:** Either:
+1. Cache the user's GitHub provider account ID on the `users` table during auth signup/link, avoiding the need to query `authAccounts` at claim time
+2. Check if `@convex-dev/auth` exposes a utility to look up accounts by userId+provider efficiently
+
+The `claimSkill` operation is rare, so this is low urgency but worth addressing if the `authAccounts` table grows large.
+
+**Files:** `convex/skills.ts` (lines ~685-694, ~728-736)
+
 ## Revision All SKILL.md
 
 Review and improve all uploaded `SKILL.md` files using the skill-creator tool from Anthropic.

--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -73,26 +73,33 @@ export const list = query({
     const ownerDocs = await Promise.all(ownerIds.map((id) => ctx.db.get(id)));
     const ownerMap = new Map(ownerIds.map((id, i) => [id, ownerDocs[i]]));
 
-    const enriched = await Promise.all(
-      paginatedResult.page.map(async (agent) => {
-        const owner = ownerMap.get(agent.ownerUserId);
-        const latestVersion = agent.latestVersionId
-          ? await ctx.db.get(agent.latestVersionId)
-          : null;
-        return {
-          _id: agent._id,
-          slug: agent.slug,
-          displayName: agent.displayName,
-          summary: agent.summary,
-          stats: agent.stats,
-          badges: agent.badges,
-          updatedAt: agent.updatedAt,
-          latestVersionString: latestVersion?.version ?? null,
-          totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
-          owner: owner ? { handle: owner.handle, image: owner.image } : null,
-        };
-      }),
-    );
+    // Batch-fetch latest versions to avoid N+1 queries
+    const versionIds = [...new Set(
+      paginatedResult.page
+        .map((a) => a.latestVersionId)
+        .filter((id): id is NonNullable<typeof id> => id != null),
+    )];
+    const versionDocs = await Promise.all(versionIds.map((id) => ctx.db.get(id)));
+    const versionMap = new Map(versionIds.map((id, i) => [id, versionDocs[i]]));
+
+    const enriched = paginatedResult.page.map((agent) => {
+      const owner = ownerMap.get(agent.ownerUserId);
+      const latestVersion = agent.latestVersionId
+        ? versionMap.get(agent.latestVersionId) ?? null
+        : null;
+      return {
+        _id: agent._id,
+        slug: agent.slug,
+        displayName: agent.displayName,
+        summary: agent.summary,
+        stats: agent.stats,
+        badges: agent.badges,
+        updatedAt: agent.updatedAt,
+        latestVersionString: latestVersion?.version ?? null,
+        totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
+        owner: owner ? { handle: owner.handle, image: owner.image } : null,
+      };
+    });
 
     return {
       ...paginatedResult,

--- a/convex/counters.ts
+++ b/convex/counters.ts
@@ -1,15 +1,25 @@
 import { query } from "./_generated/server";
 
+const COUNTER_NAMES = ["skills", "roles", "agents", "memories"] as const;
+
 /**
  * Get counts for all resource types.
+ * Uses indexed lookups instead of a full table scan.
  */
 export const getCounts = query({
   args: {},
   handler: async (ctx) => {
-    const rows = await ctx.db.query("counters").collect();
     const result: Record<string, number> = {};
+    const rows = await Promise.all(
+      COUNTER_NAMES.map((name) =>
+        ctx.db
+          .query("counters")
+          .withIndex("by_name", (q) => q.eq("name", name))
+          .first(),
+      ),
+    );
     for (const row of rows) {
-      result[row.name] = row.count;
+      if (row) result[row.name] = row.count;
     }
     return result;
   },

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -9,4 +9,7 @@ const crons = cronJobs();
 // a single batched patch covers all accumulated events.
 crons.interval("flush stat events", { minutes: 15 }, internal.statEvents.flushStatEvents);
 
+// Clean up expired rate limit records every hour to prevent unbounded table growth.
+crons.interval("cleanup rate limits", { hours: 1 }, internal.lib.rateLimit.cleanup);
+
 export default crons;

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -104,6 +104,7 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
 
   // Resolve transitive dependencies (skills + roles) with version awareness
   const MAX_DEPTH = 100;
+  const MAX_RESOLVED = 500;
   const resolved: Array<{ kind: "skill" | "role"; slug: string; version: string }> = [];
   const resolvedKeys = new Set<string>();
   const visiting = new Set<string>();
@@ -111,6 +112,9 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
   async function resolveSkill(depSpec: string, depth: number) {
     if (depth > MAX_DEPTH) {
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
+    }
+    if (resolvedKeys.size >= MAX_RESOLVED) {
+      throw new Error(`Too many dependencies (>${MAX_RESOLVED})`);
     }
     const spec = parseDependencySpec(depSpec);
     if (spec.operator === "wildcard") return; // "*" is not a real package
@@ -152,6 +156,9 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
   async function resolveRole(depSpec: string, depth: number) {
     if (depth > MAX_DEPTH) {
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
+    }
+    if (resolvedKeys.size >= MAX_RESOLVED) {
+      throw new Error(`Too many dependencies (>${MAX_RESOLVED})`);
     }
     const spec = parseDependencySpec(depSpec);
     if (spec.operator === "wildcard") return; // "*" is not a real package

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -105,6 +105,7 @@ export async function handleResolveSkillDeps(ctx: any, request: Request): Promis
 
   // Resolve transitive dependencies (skills only)
   const MAX_DEPTH = 100;
+  const MAX_RESOLVED = 500;
   const resolved: Array<{ kind: "skill"; slug: string; version: string }> = [];
   const resolvedKeys = new Set<string>();
   const visiting = new Set<string>();
@@ -112,6 +113,9 @@ export async function handleResolveSkillDeps(ctx: any, request: Request): Promis
   async function resolveSkill(depSpec: string, depth: number) {
     if (depth > MAX_DEPTH) {
       throw new Error(`Dependency tree too deep (>${MAX_DEPTH} levels)`);
+    }
+    if (resolvedKeys.size >= MAX_RESOLVED) {
+      throw new Error(`Too many dependencies (>${MAX_RESOLVED})`);
     }
     const spec = parseDependencySpec(depSpec);
     if (spec.operator === "wildcard") return; // "*" is not a real package

--- a/convex/lib/rateLimit.ts
+++ b/convex/lib/rateLimit.ts
@@ -35,6 +35,29 @@ export const check = internalQuery({
 });
 
 /**
+ * Clean up expired rate limit records.
+ * Called by cron to prevent unbounded table growth.
+ */
+export const cleanup = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const maxWindowMs = Math.max(...Object.values(RATE_LIMITS).map((r) => r.windowMs));
+    const cutoff = now - maxWindowMs * 2; // 2x window to be safe
+
+    const expired = await ctx.db
+      .query("rateLimits")
+      .filter((q) => q.lt(q.field("windowStart"), cutoff))
+      .take(500);
+
+    for (const record of expired) {
+      await ctx.db.delete(record._id);
+    }
+    return { deleted: expired.length };
+  },
+});
+
+/**
  * Phase 2: Consume a rate limit token (only called after check passes).
  */
 export const consume = internalMutation({

--- a/convex/memories.ts
+++ b/convex/memories.ts
@@ -72,26 +72,33 @@ export const list = query({
     const ownerDocs = await Promise.all(ownerIds.map((id) => ctx.db.get(id)));
     const ownerMap = new Map(ownerIds.map((id, i) => [id, ownerDocs[i]]));
 
-    const enriched = await Promise.all(
-      paginatedResult.page.map(async (memory) => {
-        const owner = ownerMap.get(memory.ownerUserId);
-        const latestVersion = memory.latestVersionId
-          ? await ctx.db.get(memory.latestVersionId)
-          : null;
-        return {
-          _id: memory._id,
-          slug: memory.slug,
-          displayName: memory.displayName,
-          summary: memory.summary,
-          stats: memory.stats,
-          badges: memory.badges,
-          updatedAt: memory.updatedAt,
-          latestVersionString: latestVersion?.version ?? null,
-          totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
-          owner: owner ? { handle: owner.handle, image: owner.image } : null,
-        };
-      }),
-    );
+    // Batch-fetch latest versions to avoid N+1 queries
+    const versionIds = [...new Set(
+      paginatedResult.page
+        .map((m) => m.latestVersionId)
+        .filter((id): id is NonNullable<typeof id> => id != null),
+    )];
+    const versionDocs = await Promise.all(versionIds.map((id) => ctx.db.get(id)));
+    const versionMap = new Map(versionIds.map((id, i) => [id, versionDocs[i]]));
+
+    const enriched = paginatedResult.page.map((memory) => {
+      const owner = ownerMap.get(memory.ownerUserId);
+      const latestVersion = memory.latestVersionId
+        ? versionMap.get(memory.latestVersionId) ?? null
+        : null;
+      return {
+        _id: memory._id,
+        slug: memory.slug,
+        displayName: memory.displayName,
+        summary: memory.summary,
+        stats: memory.stats,
+        badges: memory.badges,
+        updatedAt: memory.updatedAt,
+        latestVersionString: latestVersion?.version ?? null,
+        totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
+        owner: owner ? { handle: owner.handle, image: owner.image } : null,
+      };
+    });
 
     return {
       ...paginatedResult,

--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -72,26 +72,33 @@ export const list = query({
     const ownerDocs = await Promise.all(ownerIds.map((id) => ctx.db.get(id)));
     const ownerMap = new Map(ownerIds.map((id, i) => [id, ownerDocs[i]]));
 
-    const enriched = await Promise.all(
-      paginatedResult.page.map(async (role) => {
-        const owner = ownerMap.get(role.ownerUserId);
-        const latestVersion = role.latestVersionId
-          ? await ctx.db.get(role.latestVersionId)
-          : null;
-        return {
-          _id: role._id,
-          slug: role.slug,
-          displayName: role.displayName,
-          summary: role.summary,
-          stats: role.stats,
-          badges: role.badges,
-          updatedAt: role.updatedAt,
-          latestVersionString: latestVersion?.version ?? null,
-          totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
-          owner: owner ? { handle: owner.handle, image: owner.image } : null,
-        };
-      }),
-    );
+    // Batch-fetch latest versions to avoid N+1 queries
+    const versionIds = [...new Set(
+      paginatedResult.page
+        .map((r) => r.latestVersionId)
+        .filter((id): id is NonNullable<typeof id> => id != null),
+    )];
+    const versionDocs = await Promise.all(versionIds.map((id) => ctx.db.get(id)));
+    const versionMap = new Map(versionIds.map((id, i) => [id, versionDocs[i]]));
+
+    const enriched = paginatedResult.page.map((role) => {
+      const owner = ownerMap.get(role.ownerUserId);
+      const latestVersion = role.latestVersionId
+        ? versionMap.get(role.latestVersionId) ?? null
+        : null;
+      return {
+        _id: role._id,
+        slug: role.slug,
+        displayName: role.displayName,
+        summary: role.summary,
+        stats: role.stats,
+        badges: role.badges,
+        updatedAt: role.updatedAt,
+        latestVersionString: latestVersion?.version ?? null,
+        totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
+        owner: owner ? { handle: owner.handle, image: owner.image } : null,
+      };
+    });
 
     return {
       ...paginatedResult,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -73,26 +73,33 @@ export const list = query({
     const ownerDocs = await Promise.all(ownerIds.map((id) => ctx.db.get(id)));
     const ownerMap = new Map(ownerIds.map((id, i) => [id, ownerDocs[i]]));
 
-    const enriched = await Promise.all(
-      paginatedResult.page.map(async (skill) => {
-        const owner = ownerMap.get(skill.ownerUserId);
-        const latestVersion = skill.latestVersionId
-          ? await ctx.db.get(skill.latestVersionId)
-          : null;
-        return {
-          _id: skill._id,
-          slug: skill.slug,
-          displayName: skill.displayName,
-          summary: skill.summary,
-          stats: skill.stats,
-          badges: skill.badges,
-          updatedAt: skill.updatedAt,
-          latestVersionString: latestVersion?.version ?? null,
-          totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
-          owner: owner ? { handle: owner.handle, image: owner.image } : null,
-        };
-      }),
-    );
+    // Batch-fetch latest versions to avoid N+1 queries
+    const versionIds = [...new Set(
+      paginatedResult.page
+        .map((s) => s.latestVersionId)
+        .filter((id): id is NonNullable<typeof id> => id != null),
+    )];
+    const versionDocs = await Promise.all(versionIds.map((id) => ctx.db.get(id)));
+    const versionMap = new Map(versionIds.map((id, i) => [id, versionDocs[i]]));
+
+    const enriched = paginatedResult.page.map((skill) => {
+      const owner = ownerMap.get(skill.ownerUserId);
+      const latestVersion = skill.latestVersionId
+        ? versionMap.get(skill.latestVersionId) ?? null
+        : null;
+      return {
+        _id: skill._id,
+        slug: skill.slug,
+        displayName: skill.displayName,
+        summary: skill.summary,
+        stats: skill.stats,
+        badges: skill.badges,
+        updatedAt: skill.updatedAt,
+        latestVersionString: latestVersion?.version ?? null,
+        totalSize: latestVersion?.files?.reduce((sum: number, f: { size: number }) => sum + f.size, 0) ?? 0,
+        owner: owner ? { handle: owner.handle, image: owner.image } : null,
+      };
+    });
 
     return {
       ...paginatedResult,


### PR DESCRIPTION
## Summary
- **N+1 query fix**: Batch-fetch `latestVersionId` documents before mapping in all four list queries (skills, roles, agents, memories) instead of per-item `await db.get()`
- **Counters indexed lookup**: Replace `.collect()` full table scan with parallel indexed lookups by counter name
- **Rate limit cleanup cron**: Add hourly cron to delete expired rate limit records, preventing unbounded table growth
- **Dependency resolver breadth limit**: Add `MAX_RESOLVED=500` cap to both skill and role dependency resolvers to prevent runaway resolution
- **TODO.md**: Document remaining high/medium scalability items (star OCC contention, starred IDs cap, authAccounts filter)

## Test plan
- [x] All 242 vitest tests pass
- [x] All 276 pytest tests pass
- [x] No API response shape changes — purely backend performance improvements
- [x] Verified no user-facing behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)