### PR TITLE
Fix inaccurate file size limits in documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,7 +47,7 @@ Four content types with parallel structure:
 
 Markdown instruction modules that agents load into context. Based on the [Agent Skills](https://agentskills.io/) open spec, extended with `metadata.strawpot` for dependencies and tool declarations.
 
-- **Files:** `SKILL.md` (required) + supporting text files (optional, up to 100 files, 512 KB each)
+- **Files:** `SKILL.md` (required) + supporting text files (optional, up to 100 files, 10 MB each, 50 MB total)
 - **Dependencies:** flat list of other skill slugs
 - **Allowed file types:** `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 

--- a/docs/content-format.md
+++ b/docs/content-format.md
@@ -209,7 +209,7 @@ During `strawhub install` / `strawhub update`, the CLI checks if each declared t
 ## File Constraints
 
 ### Skills and Roles
-- Up to 100 files per package, 512 KB each
+- Up to 100 files per package, 10 MB each, 50 MB total
 - Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 - Roles must contain exactly one file named `ROLE.md`
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -66,7 +66,7 @@ payload: { slug, displayName, version, changelog, dependencies?, customTags?, fi
 
 The `dependencies` field is optional JSON: `{"skills": ["security-baseline", "git-workflow==1.0.0"]}`. Skills can only depend on other skills. If omitted, dependencies are read from `metadata.strawpot.dependencies` in the SKILL.md frontmatter.
 
-File constraints: up to 100 files, 512 KB each. Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`.
+File constraints: up to 100 files, 10 MB each, 50 MB total. Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`.
 
 Additional constraints:
 - Slug must be unique within skills.

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,12 +66,12 @@ All rate limits are per IP address.
 ## Upload constraints
 
 ### Skills and Roles
-- Max 20 files per package, 512 KB each
+- Max 100 files per package, 10 MB each, 50 MB total
 - Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.toml`
 - Roles must contain exactly one file (`ROLE.md`)
 
 ### Agents and Memories
-- Max 50 files per package, 10 MB each, 50 MB total
+- Max 100 files per package, 10 MB each, 50 MB total
 - Supports binary files (compiled executables, data files)
 
 ### All types

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -167,7 +167,7 @@ When a consumer (StrawPot CLI) installs a role:
 3. Topological sort with cycle detection
 4. Return install order (leaves first)
 
-The resolution logic exists server-side (handler in `rolesV1.ts`) but is not yet routed as an HTTP endpoint. When wired up, it will return:
+The resolution endpoint is live at `GET /api/v1/roles/:slug/resolve` (and `GET /api/v1/skills/:slug/resolve` for skills). Both enforce a depth limit of 100 levels and a breadth limit of 500 resolved dependencies. Response format:
 
 ```json
 {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,7 +40,7 @@ Common causes:
 - **Version not greater**: new versions must be strictly greater than the latest published version
 - **Slug taken**: another user owns the slug — choose a different name
 - **Dependency validation**: one or more declared dependencies don't exist or no published version satisfies the constraint. All issues are reported together
-- **File too large**: max 512 KB per file, max 20 files per package
+- **File too large**: max 10 MB per file, max 100 files per package, 50 MB total
 - **Missing SKILL.md / ROLE.md**: the target directory must contain the required file
 
 ## Install issues


### PR DESCRIPTION
## Summary
- Fix outdated 512 KB / 20-file limits across 5 docs files and DESIGN.md to match actual limits (10 MB per file, 100 files, 50 MB total)
- Fix agents/memories file count from 50 to 100 in security.md
- Update resolve endpoint status from "not yet routed" to live with depth/breadth limits in spec.md

## Test plan
- [ ] Verify limits in docs match `publishValidation.ts` constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)