### PR TITLE
Revert track_download debug and add install not-found tests

### DIFF
--- a/cli/src/strawhub/client.py
+++ b/cli/src/strawhub/client.py
@@ -218,11 +218,14 @@ class StrawHubClient:
     # ── Downloads ──────────────────────────────────────────────────────────────
 
     def track_download(self, kind: str, slug: str, version: str | None = None) -> None:
-        """Track a download event. Temporarily raises on error to debug repeated downloads."""
+        """Track a download event. Fire-and-forget — errors are silently ignored."""
         body: dict = {"kind": kind, "slug": slug}
         if version:
             body["version"] = version
-        self._request("POST", "/api/v1/downloads", json=body)
+        try:
+            self._request("POST", "/api/v1/downloads", json=body)
+        except Exception:
+            pass  # Best-effort, don't fail installs over tracking
 
     # ── Stars ─────────────────────────────────────────────────────────────────
 

--- a/cli/tests/test_client.py
+++ b/cli/tests/test_client.py
@@ -182,7 +182,6 @@ class TestDeletePackage:
 
 
 class TestTrackDownload:
-    @pytest.mark.skip(reason="Temporarily raising errors to debug repeated downloads")
     def test_fire_and_forget_swallows_errors(self, client):
         """track_download silently ignores errors — never raises."""
         client._request = MagicMock(side_effect=Exception("network error"))

--- a/cli/tests/test_install.py
+++ b/cli/tests/test_install.py
@@ -5,10 +5,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from strawhub.commands.install import (
+    _install_impl,
     _resolve_deps,
     _slug_installed_in_scope,
     _download_package,
 )
+from strawhub.errors import NotFoundError
 
 
 class TestResolveDepsWildcard:
@@ -66,6 +68,36 @@ class TestResolveDepsWildcard:
         client = MagicMock()
         result = _resolve_deps(client, "memory", "my-mem", {})
         assert result == []
+
+
+class TestInstallNotFound:
+    def test_nonexistent_slug_exits_with_error(self, tmp_path):
+        """Installing a slug that doesn't exist prints an error and exits 1."""
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get_info.side_effect = NotFoundError("Not found")
+
+        with patch("strawhub.commands.install.StrawHubClient", return_value=mock_client), \
+             patch("strawhub.commands.install.get_root", return_value=tmp_path), \
+             patch("strawhub.commands.install.get_lockfile_path", return_value=tmp_path / "lockfile.json"):
+            with pytest.raises(SystemExit) as exc_info:
+                _install_impl("imu", kind="role", is_global=False)
+            assert exc_info.value.code == 1
+
+    def test_nonexistent_slug_does_not_track_download(self, tmp_path):
+        """When slug doesn't exist, track_download should never be called."""
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get_info.side_effect = NotFoundError("Not found")
+
+        with patch("strawhub.commands.install.StrawHubClient", return_value=mock_client), \
+             patch("strawhub.commands.install.get_root", return_value=tmp_path), \
+             patch("strawhub.commands.install.get_lockfile_path", return_value=tmp_path / "lockfile.json"):
+            with pytest.raises(SystemExit):
+                _install_impl("imu", kind="role", is_global=False)
+            mock_client.track_download.assert_not_called()
 
 
 class TestSlugInstalledInScope:


### PR DESCRIPTION
## Summary
- Reverts the temporary error raising in `track_download` (restores fire-and-forget behavior)
- Removes the `@pytest.mark.skip` on the swallowed-errors test
- Adds two new tests verifying that installing a nonexistent slug (`imu`) exits with code 1 and never calls `track_download`

## Test plan
- [x] `test_nonexistent_slug_exits_with_error` — confirms `SystemExit(1)`
- [x] `test_nonexistent_slug_does_not_track_download` — confirms no download tracking on 404
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)