### PR TITLE
Return 404 from download tracking for missing slugs

### DIFF
--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -27,7 +27,7 @@ export const trackDownload = mutation({
       .query(table)
       .withIndex("by_slug", (q: any) => q.eq("slug", args.slug))
       .first();
-    if (!target) return;
+    if (!target) return { found: false };
 
     // Resolve version ID if provided
     let versionId: string | undefined;
@@ -78,7 +78,7 @@ export const trackDownload = mutation({
             .eq("versionId", versionId),
         )
         .first();
-      if (existing) return;
+      if (existing) return { found: true };
     }
 
     await ctx.db.insert("statEvents", {
@@ -89,5 +89,6 @@ export const trackDownload = mutation({
       userId: args.userId,
       createdAt: Date.now(),
     });
+    return { found: true };
   },
 });

--- a/convex/httpApiV1/downloadsV1.ts
+++ b/convex/httpApiV1/downloadsV1.ts
@@ -44,12 +44,16 @@ export const trackDownload = httpAction(async (ctx, request) => {
     }
   }
 
-  await ctx.runMutation(api.downloads.trackDownload, {
+  const result = await ctx.runMutation(api.downloads.trackDownload, {
     targetKind: kind as "skill" | "role" | "agent" | "memory",
     slug,
     version,
     userId,
   });
+
+  if (result && !result.found) {
+    return errorResponse(`${kind} '${slug}' not found`, 404);
+  }
 
   return jsonResponse({ ok: true });
 });


### PR DESCRIPTION
## Summary
- `trackDownload` mutation now returns `{ found: bool }` instead of silently returning `void` when the slug doesn't exist
- HTTP handler returns 404 with `"<kind> '<slug>' not found"` when the slug is missing, instead of always returning `{ ok: true }`

## Test plan
- [ ] `POST /api/v1/downloads` with a nonexistent slug returns 404
- [ ] `POST /api/v1/downloads` with a valid slug still returns `{ ok: true }`
- [ ] Deduplicated downloads (existing user+target+version) still return `{ ok: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)