### PR TITLE
Make integration install/uninstall/update global-only

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -649,13 +649,6 @@ def install_memory(slug, is_global, skip_tools, yes, update, ver, force, save, s
 @install.command("integration")
 @click.argument("slug")
 @click.option(
-    "--global",
-    "is_global",
-    is_flag=True,
-    default=False,
-    help="Install to global directory (~/.strawpot or STRAWPOT_HOME)",
-)
-@click.option(
     "--skip-tools",
     is_flag=True,
     default=False,
@@ -686,43 +679,23 @@ def install_memory(slug, is_global, skip_tools, yes, update, ver, force, save, s
     default=False,
     help="With --version, force replace an existing installation",
 )
-@click.option(
-    "--save",
-    is_flag=True,
-    default=False,
-    help="Save dependency to strawpot.toml with ^X.Y.Z constraint",
-)
-@click.option(
-    "--save-exact",
-    is_flag=True,
-    default=False,
-    help="Save dependency to strawpot.toml with ==X.Y.Z constraint",
-)
-def install_integration(slug, is_global, skip_tools, yes, update, ver, force, save, save_exact):
-    """Install an integration."""
+def install_integration(slug, skip_tools, yes, update, ver, force):
+    """Install an integration (always global)."""
     if force and not ver:
         print_error("--force requires --version")
         raise SystemExit(1)
     if update and ver:
         print_error("--update and --version cannot be used together")
         raise SystemExit(1)
-    if save and save_exact:
-        print_error("--save and --save-exact cannot be used together")
-        raise SystemExit(1)
-    if (save or save_exact) and is_global:
-        print_error("--save/--save-exact cannot be used with --global")
-        raise SystemExit(1)
     _install_impl(
         slug,
         kind="integration",
-        is_global=is_global,
+        is_global=True,
         skip_tools=skip_tools,
         yes=yes,
         update=update,
         version=ver,
         force=force,
-        save=save,
-        save_exact=save_exact,
     )
 
 

--- a/cli/src/strawhub/commands/uninstall.py
+++ b/cli/src/strawhub/commands/uninstall.py
@@ -16,7 +16,7 @@ from strawhub.project_file import ProjectFile
 @click.group(invoke_without_command=True)
 @click.pass_context
 def uninstall(ctx):
-    """Remove an installed skill, role, agent, or memory and clean up orphaned dependencies."""
+    """Remove an installed skill, role, agent, memory, or integration and clean up orphaned dependencies."""
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
         ctx.exit(1)
@@ -115,6 +115,14 @@ def uninstall_agent(slug, ver, is_global, save):
 def uninstall_memory(slug, ver, is_global, save):
     """Remove an installed memory and clean up orphaned dependencies."""
     _uninstall_impl(slug, kind="memory", ver=ver, is_global=is_global, save=save)
+
+
+@uninstall.command("integration")
+@click.argument("slug")
+@click.option("--version", "ver", default=None, help="Specific version to remove (removes all versions if omitted)")
+def uninstall_integration(slug, ver):
+    """Remove an installed integration (always global)."""
+    _uninstall_impl(slug, kind="integration", ver=ver, is_global=True)
 
 
 def _find_targets(

--- a/cli/src/strawhub/commands/update.py
+++ b/cli/src/strawhub/commands/update.py
@@ -47,7 +47,7 @@ from strawhub.project_file import ProjectFile
 )
 @click.pass_context
 def update(ctx, update_all, is_global, skip_tools, yes, save):
-    """Update installed skills/roles/agents/memories to their latest versions."""
+    """Update installed skills/roles/agents/memories/integrations to their latest versions."""
     if save and is_global:
         print_error("--save cannot be used with --global")
         raise SystemExit(1)
@@ -55,7 +55,7 @@ def update(ctx, update_all, is_global, skip_tools, yes, save):
         _update_all_impl(is_global, skip_tools=skip_tools, yes=yes, save=save)
         return
     if ctx.invoked_subcommand is None:
-        click.echo("Specify 'skill <slug>', 'role <slug>', 'agent <slug>', 'memory <slug>', or use --all.")
+        click.echo("Specify 'skill <slug>', 'role <slug>', 'agent <slug>', 'memory <slug>', 'integration <slug>', or use --all.")
         ctx.exit(1)
 
 
@@ -157,3 +157,10 @@ def update_agent(slug, is_global, save):
 def update_memory(slug, is_global, save):
     """Update an installed memory to its latest version."""
     _update_one_impl(slug, kind="memory", is_global=is_global, save=save)
+
+
+@update.command("integration")
+@click.argument("slug")
+def update_integration(slug):
+    """Update an installed integration to its latest version (always global)."""
+    _update_one_impl(slug, kind="integration", is_global=True)


### PR DESCRIPTION
## Summary
- Remove `--global`, `--save`, `--save-exact` flags from `install integration` — always installs to global scope (`~/.strawpot/integrations/`)
- Add missing `uninstall integration` subcommand (global-only)
- Add missing `update integration` subcommand (global-only)
- Aligns CLI with strawpot's design: integrations are global-only (GUI scans `~/.strawpot/integrations/`)

## Test plan
- [x] All 278 CLI tests pass
- [ ] `strawhub install integration <slug>` installs to global without needing `--global`
- [ ] `strawhub uninstall integration <slug>` removes from global
- [ ] `strawhub update integration <slug>` updates in global

🤖 Generated with [Claude Code](https://claude.com/claude-code)