### PR TITLE
Add CLI validate command and improve project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,36 @@
 # Contributing to StrawHub
 
+## Architecture at a Glance
+
+StrawHub is a three-tier monorepo: React frontend, Convex backend, Python CLI.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  src/           Convex client (real-time queries)   │  ← React SPA
+│  convex/        DB + file storage + HTTP API        │  ← Serverless backend
+│  cli/           REST API client (Bearer token)      │  ← Python CLI (PyPI)
+└─────────────────────────────────────────────────────┘
+```
+
+**Key files to understand first:**
+
+| File | What it does |
+|------|-------------|
+| `convex/schema.ts` | Single source of truth for the database schema |
+| `convex/lib/publishValidation.ts` | All publish-time constraints (slug, version, file limits) |
+| `convex/http.ts` | HTTP route definitions — maps URLs to handlers |
+| `convex/httpApiV1/` | REST API v1 handler implementations |
+| `cli/src/strawhub/cli.py` | CLI entry point — all commands registered here |
+| `cli/src/strawhub/resolver.py` | Dependency resolution (client-side DFS for skills) |
+| `cli/src/strawhub/client.py` | HTTP client that talks to the REST API |
+| `src/routes/` | Frontend pages (file-based routing via TanStack Router) |
+
+**Content types** — Five parallel types: skills, roles, agents, memories, integrations. Each has its own DB tables, API endpoints, and CLI subcommands. Roles and skills form the dependency graph (core); agents, memories, and integrations are standalone extensions.
+
+**Where validation lives** — Constraints are enforced server-side in `convex/lib/publishValidation.ts`. The CLI `validate` command mirrors these checks client-side in `cli/src/strawhub/commands/validate.py`. Keep them in sync.
+
+See [DESIGN.md](DESIGN.md) for the full architecture.
+
 ## Tech Stack
 
 - **Frontend**: Vite + React 19 + TanStack Router + Tailwind CSS v4
@@ -94,8 +125,23 @@ Set `VITE_CONVEX_URL` in the Vercel dashboard (Settings > Environment Variables)
 
 The CLI is published on [PyPI](https://pypi.org/project/strawhub/). See [docs/cli.md](docs/cli.md) for the full command reference.
 
+```bash
+# Run CLI tests
+cd cli && python -m pytest tests/ -v
+```
+
 ## API
 
 See [docs/http-api.md](docs/http-api.md) for the full HTTP API reference.
 
 Authenticated endpoints require an `Authorization: Bearer <token>` header. Create tokens from the Settings page.
+
+## Where to Start
+
+**Adding a new content type** — Follow the pattern of any existing type (e.g., `integrations`). You'll need: DB tables in `schema.ts`, queries/mutations in `convex/`, API handlers in `httpApiV1/`, frontend routes in `src/routes/`, and CLI subcommands.
+
+**Adding a CLI command** — Create a file in `cli/src/strawhub/commands/`, register it in `cli.py`, add tests in `cli/tests/`, and document it in `docs/cli.md`.
+
+**Modifying validation rules** — Update `convex/lib/publishValidation.ts` (server-side) and `cli/src/strawhub/commands/validate.py` (client-side) together.
+
+**Frontend pages** — Each content type has three routes: `{type}.tsx` (layout), `{type}.index.tsx` (list), `{type}.$slug.tsx` (detail). Follow the existing pattern.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,9 +39,36 @@ Three-tier monorepo: React frontend, Convex backend, Python CLI.
 
 **CLI** (`cli/`) — Python Click-based CLI published to PyPI as `strawhub`. Communicates with the backend exclusively through the REST API using Bearer token auth.
 
+## Open vs Hosted Boundary
+
+StrawHub has two layers: an **open package format** and a **hosted registry service**.
+
+### Open layer (format + CLI)
+
+Everything needed to create, validate, and install packages locally:
+
+- **Package format** — YAML frontmatter + Markdown body in `SKILL.md`, `ROLE.md`, `AGENT.md`, `MEMORY.md`, or `INTEGRATION.md`. Plain files, no proprietary encoding.
+- **Dependency spec** — Skills declare flat dependency lists; roles declare structured `skills` + `roles` dependencies. Resolution is deterministic and can run client-side.
+- **File constraints** — Max 100 files, 10 MB each, 50 MB total. Slug format: lowercase alphanumeric + hyphens, max 64 chars. Semver versioning.
+- **CLI** — `strawhub validate` checks a package locally. `strawhub install` / `publish` / `resolve` work against any registry endpoint (override via `STRAWHUB_API_URL`).
+
+The format and CLI are MIT-licensed. Anyone can build tools that produce or consume StrawHub packages without depending on strawhub.dev.
+
+### Hosted layer (strawhub.dev)
+
+The registry service adds discovery, trust, and namespace management:
+
+- **Search & discovery** — Hybrid vector + lexical search, download rankings, curated tags
+- **Namespace ownership** — First publisher owns the slug per content type. Only the owner can push new versions.
+- **Trust signals** — VirusTotal malware scanning, download stats, star counts, moderation reports
+- **Authentication** — GitHub OAuth for web, Bearer tokens for API/CLI
+- **Moderation** — Admin soft-delete, user bans, audit logging
+
+The hosted layer runs on Convex (serverless backend) + Vercel (frontend). It is the default registry but not the only possible one — the CLI's `STRAWHUB_API_URL` env var can point to any compatible endpoint.
+
 ## Content Model
 
-Five content types with parallel structure:
+Five content types, split into **core** (roles and skills — the dependency graph) and **extensions** (agents, memories, integrations — standalone packages):
 
 ### Skills
 

--- a/README.md
+++ b/README.md
@@ -59,36 +59,41 @@ That's it. StrawHub resolves every skill and sub-role your AI CEO needs. StrawPo
 ┌──────────────────────────────────────────────────────┐
 │                       StrawHub                       │
 │                                                      │
-│   Skills          Roles          Memories            │
-│  ┌──────────┐   ┌──────────┐   ┌──────────┐          │
-│  │git-wflow │   │ai-ceo    │   │proj-ctx  │          │
-│  │code-rev  │   │pm        │   │patterns  │          │
-│  │py-test   │   │implmtr   │   │decisions │          │
-│  │debugging │   │reviewer  │   │lessons   │          │
-│  └──────────┘   └──────────┘   └──────────┘          │
+│   ┌─── Core ──────────────────────────────────────┐  │
+│   │  Roles            Skills                      │  │
+│   │  ┌──────────┐    ┌──────────┐                 │  │
+│   │  │ai-ceo    │    │git-wflow │                 │  │
+│   │  │pm        │    │code-rev  │                 │  │
+│   │  │implmtr   │    │py-test   │                 │  │
+│   │  │reviewer  │    │debugging │                 │  │
+│   │  └──────────┘    └──────────┘                 │  │
+│   └───────────────────────────────────────────────┘  │
 │                                                      │
-│   Agents                    Integrations             │
-│  ┌──────────────────────┐  ┌──────────────────────┐  │
-│  │claude-code · codex   │  │telegram · slack      │  │
-│  │gemini                │  │discord               │  │
-│  └──────────────────────┘  └──────────────────────┘  │
+│   ┌─── Extensions ────────────────────────────────┐  │
+│   │  Agents          Memories      Integrations   │  │
+│   │  ┌──────────┐   ┌──────────┐  ┌──────────┐    │  │
+│   │  │claude    │   │proj-ctx  │  │telegram  │    │  │
+│   │  │codex     │   │patterns  │  │slack     │    │  │
+│   │  │gemini    │   │decisions │  │discord   │    │  │
+│   │  └──────────┘   └──────────┘  └──────────┘    │  │
+│   └───────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────┘
 ```
-
-### Skills — what agents can do
-Atomic capabilities: writing code, reviewing PRs, running tests, searching docs.
 
 ### Roles — what agents are
 Job definitions that bundle skills. An `ai-ceo` depends on `pm`, `implementer`, and `reviewer` — StrawPot handles the delegation.
 
-### Memories — what agents remember
-Persistent knowledge banks: project context, code patterns, past decisions. Install shared context from StrawHub so new agents start smart.
+### Skills — what agents can do
+Atomic capabilities: writing code, reviewing PRs, running tests, searching docs. Roles compose skills; skills are the building blocks.
 
 ### Agents — where agents run
 Runtime wrappers for Claude Code, Codex, Gemini, or your own CLI.
 
+### Memories — what agents remember
+Persistent knowledge banks: project context, code patterns, past decisions.
+
 ### Integrations — how agents connect
-Adapters that bridge StrawPot to external services like Telegram, Slack, or Discord. Always installed globally.
+Adapters that bridge StrawPot to external services like Telegram, Slack, or Discord.
 
 ## Everything Is a Markdown File
 
@@ -162,6 +167,7 @@ Skills use client-side DFS. Roles use server-side topological sort with cycle de
 # Install
 strawhub install role ai-ceo
 strawhub install skill git-workflow
+strawhub install agent strawpot-claude-code
 strawhub install memory project-context
 strawhub install integration telegram
 
@@ -170,7 +176,8 @@ strawhub search "code review"
 strawhub info role ai-ceo
 strawhub list
 
-# Publish
+# Validate & Publish
+strawhub validate skill ./my-skill/
 strawhub publish role ./my-role/
 strawhub publish skill ./my-skill/
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 # TODO
 
-## Download Deduplication
+## P0 — Data Integrity
+
+### Download Deduplication
 
 Prevent the same user/IP from inflating download counts by downloading the same item repeatedly.
 
@@ -8,7 +10,7 @@ Prevent the same user/IP from inflating download counts by downloading the same 
 
 Reference: ClawHub uses `downloadDedupes` table with compound index on `(skillId, identityHash, hourStart)`.
 
-## Stats Reconciliation Cron
+### Stats Reconciliation Cron
 
 Add a periodic reconciliation job that recounts stars and comments from source tables and corrects any drift in denormalized `stats` fields on skill/role/agent documents.
 
@@ -24,7 +26,7 @@ Run hourly or daily via cron.
 
 Reference: ClawHub's `reconcileSkillStarCounts` mutation.
 
-## Star Counter OCC Contention (High)
+### Star Counter OCC Contention
 
 Popular items receive many concurrent star/unstar operations, all patching the same `stats.stars` field on the skill/role/agent document. This causes Convex OCC (Optimistic Concurrency Control) retries under load.
 
@@ -34,7 +36,15 @@ Popular items receive many concurrent star/unstar operations, all patching the s
 
 **Files:** `convex/stars.ts`, `convex/statEvents.ts`
 
-## Frontend Download Error Handling (Medium)
+## P1 — Developer Experience
+
+### CLI `validate` Command
+
+Client-side validation of a package directory before publishing. Checks frontmatter schema, file constraints, slug format, and content type rules without requiring authentication or a network call.
+
+**Status:** Planned (this sprint).
+
+### Frontend Download Error Handling
 
 The download button's `onClick` handler in skill/role/agent detail pages calls `fetch(zipUrl)` with no `.catch()` or error feedback. If the download fails, nothing is shown to the user.
 
@@ -42,7 +52,9 @@ The download button's `onClick` handler in skill/role/agent detail pages calls `
 
 **Files:** `src/routes/skills.$slug.tsx`, `src/routes/roles.$slug.tsx`, `src/routes/agents.$slug.tsx`
 
-## CLI Tool Install Subprocess Without Timeout (Medium)
+## P2 — Reliability
+
+### CLI Tool Install Subprocess Without Timeout
 
 `subprocess.run(spec.command, shell=True)` in tool installation has no timeout. A broken or malicious install script could hang the CLI indefinitely.
 
@@ -50,6 +62,8 @@ The download button's `onClick` handler in skill/role/agent detail pages calls `
 
 **Files:** `cli/src/strawhub/tools.py` (lines ~133-146)
 
-## Revision All SKILL.md
+## P3 — Content Quality
+
+### Revision All SKILL.md
 
 Review and improve all uploaded `SKILL.md` files using the skill-creator tool from Anthropic.

--- a/cli/src/strawhub/cli.py
+++ b/cli/src/strawhub/cli.py
@@ -20,6 +20,7 @@ from strawhub.commands.delete import delete
 from strawhub.commands.ban_user import ban_user
 from strawhub.commands.set_role import set_role
 from strawhub.commands.install_tools import install_tools
+from strawhub.commands.validate import validate
 
 
 @click.group()
@@ -51,6 +52,7 @@ cli.add_command(install_tools, name="install-tools")
 cli.add_command(uninstall)
 cli.add_command(update)
 cli.add_command(publish)
+cli.add_command(validate)
 cli.add_command(resolve_cmd, name="resolve")
 cli.add_command(star)
 cli.add_command(unstar)

--- a/cli/src/strawhub/commands/validate.py
+++ b/cli/src/strawhub/commands/validate.py
@@ -1,0 +1,235 @@
+"""Validate a package directory before publishing.
+
+Checks frontmatter schema, file constraints, slug format, and
+content-type-specific rules — all offline, no auth required.
+"""
+
+import re
+from pathlib import Path
+
+import click
+
+from strawhub.display import print_success, print_error, console
+from strawhub.frontmatter import parse_frontmatter, extract_dependencies
+
+# Keep in sync with convex/lib/publishValidation.ts
+SLUG_REGEX = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+MAX_SLUG_LENGTH = 64
+MAX_DISPLAY_NAME_LENGTH = 128
+MAX_FILE_COUNT = 100
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB per file
+MAX_TOTAL_SIZE = 50 * 1024 * 1024  # 50 MB total
+MAX_DEPENDENCIES = 50
+
+# Allowed text extensions for skills (no binaries)
+SKILL_TEXT_EXTENSIONS = {
+    ".md", ".mdx", ".txt",
+    ".json", ".json5", ".yaml", ".yml", ".toml", ".xml", ".ini", ".cfg",
+    ".env", ".csv", ".conf",
+}
+
+MAIN_FILES = {
+    "skill": "SKILL.md",
+    "role": "ROLE.md",
+    "agent": "AGENT.md",
+    "memory": "MEMORY.md",
+    "integration": "INTEGRATION.md",
+}
+
+
+def _collect_files(directory: Path) -> list[tuple[str, int]]:
+    """Collect (relative_path, size) for all non-hidden files."""
+    files = []
+    for file_path in sorted(directory.rglob("*")):
+        if file_path.is_file() and not any(
+            part.startswith(".") for part in file_path.relative_to(directory).parts
+        ):
+            relative = file_path.relative_to(directory).as_posix()
+            files.append((relative, file_path.stat().st_size))
+    return files
+
+
+def _validate_package(directory: Path, kind: str) -> list[str]:
+    """Validate a package directory. Returns a list of error messages."""
+    errors: list[str] = []
+    main_file = MAIN_FILES[kind]
+    main_path = directory / main_file
+
+    # --- Main file exists ---
+    if not main_path.exists():
+        errors.append(f"Missing required file: {main_file}")
+        return errors  # Can't continue without main file
+
+    # --- Parse frontmatter ---
+    try:
+        content = main_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        errors.append(f"{main_file} is not valid UTF-8 text")
+        return errors
+
+    parsed = parse_frontmatter(content)
+    fm = parsed.get("frontmatter", {})
+
+    # --- name field ---
+    slug = fm.get("name") or fm.get("slug")
+    if not slug:
+        errors.append(f"Missing 'name' field in {main_file} frontmatter")
+    elif not isinstance(slug, str):
+        errors.append(f"'name' field must be a string, got {type(slug).__name__}")
+    else:
+        if len(slug) > MAX_SLUG_LENGTH:
+            errors.append(f"Slug exceeds {MAX_SLUG_LENGTH} characters: '{slug}'")
+        if not SLUG_REGEX.match(slug):
+            errors.append(
+                f"Invalid slug '{slug}': must be lowercase alphanumeric with hyphens, "
+                "starting with alphanumeric"
+            )
+
+    # --- description field ---
+    desc = fm.get("description")
+    if not desc:
+        errors.append(f"Missing 'description' field in {main_file} frontmatter")
+
+    # --- displayName length ---
+    display_name = fm.get("displayName") or fm.get("display_name")
+    if display_name and len(str(display_name)) > MAX_DISPLAY_NAME_LENGTH:
+        errors.append(
+            f"Display name exceeds {MAX_DISPLAY_NAME_LENGTH} characters"
+        )
+
+    # --- version format (if present) ---
+    version = fm.get("version")
+    if version:
+        version_str = str(version)
+        if not re.match(r"^\d+\.\d+\.\d+$", version_str):
+            errors.append(f"Invalid version '{version_str}': must be X.Y.Z semver")
+
+    # --- Collect files ---
+    files = _collect_files(directory)
+
+    if not files:
+        errors.append("No files found in directory")
+        return errors
+
+    # --- File count ---
+    if len(files) > MAX_FILE_COUNT:
+        errors.append(f"Too many files: {len(files)} (max {MAX_FILE_COUNT})")
+
+    # --- File sizes ---
+    total_size = 0
+    for rel_path, size in files:
+        if size > MAX_FILE_SIZE:
+            errors.append(
+                f"File '{rel_path}' exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit "
+                f"({size // (1024 * 1024)}MB)"
+            )
+        total_size += size
+
+    if total_size > MAX_TOTAL_SIZE:
+        errors.append(
+            f"Total size exceeds {MAX_TOTAL_SIZE // (1024 * 1024)}MB limit "
+            f"({total_size // (1024 * 1024)}MB)"
+        )
+
+    # --- Content-type-specific rules ---
+    file_paths = [fp for fp, _ in files]
+
+    if kind == "role":
+        if len(files) != 1:
+            errors.append(
+                f"Role must contain exactly one file (ROLE.md), found {len(files)}: "
+                + ", ".join(file_paths)
+            )
+        elif file_paths[0] != "ROLE.md":
+            errors.append(f"Role must contain exactly one file: ROLE.md")
+
+    if kind == "skill":
+        # Skills only allow text files
+        for rel_path, _ in files:
+            ext = Path(rel_path).suffix.lower()
+            if ext and ext not in SKILL_TEXT_EXTENSIONS:
+                errors.append(
+                    f"Skill file '{rel_path}' has disallowed extension '{ext}' "
+                    "(skills only allow text files)"
+                )
+
+    # --- Dependencies ---
+    deps = extract_dependencies(fm, kind)
+    if deps:
+        skill_deps = deps.get("skills", [])
+        role_deps = deps.get("roles", [])
+        total_deps = len(skill_deps) + len(role_deps)
+        if total_deps > MAX_DEPENDENCIES:
+            errors.append(
+                f"Too many dependencies: {total_deps} (max {MAX_DEPENDENCIES})"
+            )
+        # Validate dependency slug format
+        for dep_slug in skill_deps + role_deps:
+            if dep_slug == "*":
+                continue  # wildcard is valid for roles
+            if not SLUG_REGEX.match(dep_slug):
+                errors.append(f"Invalid dependency slug: '{dep_slug}'")
+
+    return errors
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def validate(ctx):
+    """Validate a package directory before publishing."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(1)
+
+
+def _run_validate(path: str, kind: str) -> None:
+    directory = Path(path).resolve()
+    if not directory.is_dir():
+        print_error(f"Not a directory: {directory}")
+        raise SystemExit(1)
+
+    errors = _validate_package(directory, kind)
+
+    if errors:
+        print_error(f"Validation failed for {kind} at {directory}")
+        for err in errors:
+            console.print(f"  [red]\u2717[/red] {err}")
+        raise SystemExit(1)
+    else:
+        file_count = len(_collect_files(directory))
+        print_success(f"Valid {kind} ({file_count} file{'s' if file_count != 1 else ''})")
+
+
+@validate.command("skill")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def validate_skill(path):
+    """Validate a skill directory."""
+    _run_validate(path, "skill")
+
+
+@validate.command("role")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def validate_role(path):
+    """Validate a role directory."""
+    _run_validate(path, "role")
+
+
+@validate.command("agent")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def validate_agent(path):
+    """Validate an agent directory."""
+    _run_validate(path, "agent")
+
+
+@validate.command("memory")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def validate_memory(path):
+    """Validate a memory directory."""
+    _run_validate(path, "memory")
+
+
+@validate.command("integration")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+def validate_integration(path):
+    """Validate an integration directory."""
+    _run_validate(path, "integration")

--- a/cli/tests/test_validate.py
+++ b/cli/tests/test_validate.py
@@ -1,0 +1,275 @@
+"""Tests for the validate command."""
+
+import os
+import textwrap
+
+from click.testing import CliRunner
+
+from strawhub.cli import cli
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+class TestValidateSkill:
+    def test_valid_skill(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "A test skill"
+            ---
+            # My Skill
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Valid skill" in result.output
+
+    def test_missing_skill_md(self, tmp_path):
+        _write(tmp_path, "README.md", "# Not a skill")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Missing required file: SKILL.md" in result.output
+
+    def test_missing_name(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            description: "No name"
+            ---
+            # Oops
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Missing 'name' field" in result.output
+
+    def test_missing_description(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            ---
+            # No description
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Missing 'description' field" in result.output
+
+    def test_invalid_slug(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: My_Skill
+            description: "Bad slug"
+            ---
+            # Bad
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Invalid slug" in result.output
+
+    def test_slug_too_long(self, tmp_path):
+        long_slug = "a" * 65
+        _write(tmp_path, "SKILL.md", f"""\
+            ---
+            name: {long_slug}
+            description: "Long slug"
+            ---
+            # Long
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "exceeds 64 characters" in result.output
+
+    def test_invalid_version_format(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "Bad version"
+            version: "1.0"
+            ---
+            # Bad version
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Invalid version" in result.output
+
+    def test_disallowed_binary_file(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "Has binary"
+            ---
+            # Skill
+        """)
+        (tmp_path / "data.bin").write_bytes(b"\x00\x01\x02")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "disallowed extension" in result.output
+
+    def test_skill_with_allowed_supporting_files(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "Has extras"
+            ---
+            # Skill
+        """)
+        _write(tmp_path, "config.json", '{"key": "value"}')
+        _write(tmp_path, "data.yaml", "key: value")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code == 0
+
+
+class TestValidateRole:
+    def test_valid_role(self, tmp_path):
+        _write(tmp_path, "ROLE.md", """\
+            ---
+            name: my-role
+            description: "A test role"
+            ---
+            # My Role
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "role", str(tmp_path)])
+        assert result.exit_code == 0
+
+    def test_role_with_extra_files(self, tmp_path):
+        _write(tmp_path, "ROLE.md", """\
+            ---
+            name: my-role
+            description: "A test role"
+            ---
+            # My Role
+        """)
+        _write(tmp_path, "extra.md", "# Extra")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "role", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "exactly one file" in result.output
+
+
+class TestValidateAgent:
+    def test_valid_agent(self, tmp_path):
+        _write(tmp_path, "AGENT.md", """\
+            ---
+            name: my-agent
+            description: "A test agent"
+            ---
+            # My Agent
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "agent", str(tmp_path)])
+        assert result.exit_code == 0
+
+    def test_agent_allows_binary_files(self, tmp_path):
+        _write(tmp_path, "AGENT.md", """\
+            ---
+            name: my-agent
+            description: "Agent with binary"
+            ---
+            # Agent
+        """)
+        (tmp_path / "wrapper").write_bytes(b"\x7fELF" + b"\x00" * 100)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "agent", str(tmp_path)])
+        assert result.exit_code == 0
+
+
+class TestValidateMemory:
+    def test_valid_memory(self, tmp_path):
+        _write(tmp_path, "MEMORY.md", """\
+            ---
+            name: my-memory
+            description: "A test memory"
+            ---
+            # My Memory
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "memory", str(tmp_path)])
+        assert result.exit_code == 0
+
+
+class TestValidateIntegration:
+    def test_valid_integration(self, tmp_path):
+        _write(tmp_path, "INTEGRATION.md", """\
+            ---
+            name: my-integration
+            description: "A test integration"
+            ---
+            # My Integration
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "integration", str(tmp_path)])
+        assert result.exit_code == 0
+
+
+class TestValidateDependencies:
+    def test_valid_skill_deps(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "Skill with deps"
+            metadata:
+              strawpot:
+                dependencies:
+                  - other-skill
+                  - another-skill
+            ---
+            # Skill
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code == 0
+
+    def test_invalid_dep_slug(self, tmp_path):
+        _write(tmp_path, "SKILL.md", """\
+            ---
+            name: my-skill
+            description: "Bad dep"
+            metadata:
+              strawpot:
+                dependencies:
+                  - Invalid_Slug
+            ---
+            # Skill
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "skill", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Invalid dependency slug" in result.output
+
+    def test_wildcard_dep_allowed_for_roles(self, tmp_path):
+        _write(tmp_path, "ROLE.md", """\
+            ---
+            name: my-role
+            description: "Role with wildcard"
+            metadata:
+              strawpot:
+                dependencies:
+                  roles:
+                    - "*"
+                  skills:
+                    - some-skill
+            ---
+            # Role
+        """)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "role", str(tmp_path)])
+        assert result.exit_code == 0
+
+
+class TestValidateNoSubcommand:
+    def test_no_subcommand_shows_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate"])
+        assert result.exit_code != 0
+        assert "validate" in result.output

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ strawhub [--version] [--help] <command>
 | [`info`](#info) | Show detailed information about a package |
 | [`list`](#list) | List available skills, roles, agents, and memories |
 | [`resolve`](#resolve) | Resolve a package to its installed path and dependencies |
+| [`validate`](#validate) | Validate a package directory before publishing |
 | [`publish`](#publish) | Publish a package to the registry |
 | [`install-tools`](#install-tools) | Install system tools declared by packages |
 | [`star`](#star) / [`unstar`](#unstar) | Star or unstar a package |
@@ -478,6 +479,42 @@ Resolution checks local scope first, then global. Returns the highest installed 
 strawhub resolve skill code-review
 strawhub resolve role implementer --version 1.0.0
 strawhub resolve skill git-workflow --global
+```
+
+---
+
+## Validation
+
+### `validate`
+
+Validate a package directory before publishing. Checks frontmatter schema, file constraints, slug format, and content-type-specific rules — all offline, no auth required.
+
+```bash
+strawhub validate skill [<path>]
+strawhub validate role [<path>]
+strawhub validate agent [<path>]
+strawhub validate memory [<path>]
+strawhub validate integration [<path>]
+```
+
+Defaults to the current directory if `<path>` is omitted.
+
+**Checks performed:**
+
+- Required main file exists (`SKILL.md`, `ROLE.md`, etc.)
+- `name` field present and valid slug format (lowercase alphanumeric + hyphens, max 64 chars)
+- `description` field present
+- `version` field (if present) is valid semver (`X.Y.Z`)
+- File count within limit (max 100)
+- File sizes within limits (10 MB each, 50 MB total)
+- Content-type rules: roles must be exactly one file; skills only allow text file extensions
+- Dependency slugs are valid format
+
+**Examples:**
+
+```bash
+strawhub validate skill ./my-skill/      # validate before publishing
+strawhub validate role .                  # validate current directory
 ```
 
 ---


### PR DESCRIPTION
## Summary
- **README.md**: Reorder "What's Inside" to lead with roles + skills (core) vs agents/memories/integrations (extensions)
- **DESIGN.md**: Add "Open vs Hosted Boundary" section — distinguishes the open package format + CLI from the hosted registry service (strawhub.dev)
- **TODO.md**: Reorganize into priority tiers (P0 Data Integrity, P1 Developer Experience, P2 Reliability, P3 Content Quality)
- **CONTRIBUTING.md**: Add architecture overview with key files table and "Where to Start" guide for common contribution patterns
- **CLI `validate` command**: Offline package validation — checks frontmatter schema, file constraints, slug format, content-type rules (19 tests)
- **docs/cli.md**: Document the validate command with examples and checks list

## Test plan
- [x] 19 new tests for validate command (all passing)
- [ ] Verify `strawhub validate skill ./path/` works against a real package directory
- [ ] Verify `strawhub validate role ./path/` rejects directories with extra files

🤖 Generated with [Claude Code](https://claude.com/claude-code)