### PR TITLE
Fix display name overwritten on package update

### DIFF
--- a/cli/src/strawhub/commands/publish.py
+++ b/cli/src/strawhub/commands/publish.py
@@ -46,9 +46,7 @@ def _publish_impl(path, kind, ver, changelog, tags):
         content = rewrite_frontmatter_name(content, slug)
         name_rewritten = True
 
-    display_name = fm.get("displayName") or fm.get("display_name") or " ".join(
-        w.capitalize() for w in slug.split("-")
-    )
+    display_name = fm.get("displayName") or fm.get("display_name") or ""
     version = ver or fm.get("version")
     if not version:
         print_error(
@@ -90,10 +88,11 @@ def _publish_impl(path, kind, ver, changelog, tags):
     # Build form data
     form_data = {
         "slug": slug,
-        "displayName": display_name,
         "version": version,
         "changelog": changelog,
     }
+    if display_name:
+        form_data["displayName"] = display_name
     if tags:
         form_data["customTags"] = ",".join(tags)
     if dependencies_json:

--- a/convex/httpApiV1/agentsV1.ts
+++ b/convex/httpApiV1/agentsV1.ts
@@ -132,7 +132,7 @@ export const publishAgent = httpAction(async (ctx, request) => {
     try {
       validateSlug(slug);
       validateVersion(version);
-      validateDisplayName(displayName);
+      if (displayName) validateDisplayName(displayName);
       validateChangelog(changelog);
     } catch (e: any) {
       return errorResponse(e.message, 400);

--- a/convex/httpApiV1/integrationsV1.ts
+++ b/convex/httpApiV1/integrationsV1.ts
@@ -132,7 +132,7 @@ export const publishIntegration = httpAction(async (ctx, request) => {
     try {
       validateSlug(slug);
       validateVersion(version);
-      validateDisplayName(displayName);
+      if (displayName) validateDisplayName(displayName);
       validateChangelog(changelog);
     } catch (e: any) {
       return errorResponse(e.message, 400);

--- a/convex/httpApiV1/memoriesV1.ts
+++ b/convex/httpApiV1/memoriesV1.ts
@@ -132,7 +132,7 @@ export const publishMemory = httpAction(async (ctx, request) => {
     try {
       validateSlug(slug);
       validateVersion(version);
-      validateDisplayName(displayName);
+      if (displayName) validateDisplayName(displayName);
       validateChangelog(changelog);
     } catch (e: any) {
       return errorResponse(e.message, 400);

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -276,7 +276,7 @@ export const publishRole = httpAction(async (ctx, request) => {
     try {
       validateSlug(slug);
       validateVersion(version);
-      validateDisplayName(displayName);
+      if (displayName) validateDisplayName(displayName);
       validateChangelog(changelog);
     } catch (e: any) {
       return errorResponse(e.message, 400);

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -237,7 +237,7 @@ export const publishSkill = httpAction(async (ctx, request) => {
     try {
       validateSlug(slug);
       validateVersion(version);
-      validateDisplayName(displayName);
+      if (displayName) validateDisplayName(displayName);
       validateChangelog(changelog);
     } catch (e: any) {
       return errorResponse(e.message, 400);

--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -240,12 +240,19 @@ function UploadPage() {
           const { frontmatter } = parseFrontmatter(text);
           if (frontmatter.name && typeof frontmatter.name === "string") {
             setSlug(frontmatter.name);
-            setDisplayName(
-              frontmatter.name
-                .split("-")
-                .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-                .join(" "),
-            );
+            // Use explicit displayName from frontmatter if present;
+            // otherwise generate from slug only for new packages (not updates)
+            const fmDisplayName = frontmatter.displayName ?? frontmatter.display_name;
+            if (typeof fmDisplayName === "string" && fmDisplayName.trim()) {
+              setDisplayName(fmDisplayName.trim());
+            } else if (!updateSlug) {
+              setDisplayName(
+                frontmatter.name
+                  .split("-")
+                  .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+                  .join(" "),
+              );
+            }
           }
           const meta = frontmatter.metadata as Record<string, unknown> | undefined;
           if (meta?.version) {
@@ -254,7 +261,7 @@ function UploadPage() {
         });
       }
     },
-    [kind],
+    [kind, updateSlug],
   );
 
   const handleDrop = useCallback(


### PR DESCRIPTION
## Summary
- **Frontend**: `processFiles` in upload.tsx was unconditionally overwriting `displayName` with a title-cased slug when parsing frontmatter from uploaded/imported files. Now only auto-generates for new packages; on updates, leaves the field empty so it falls back to the existing display name at publish time.
- **CLI**: Only sends `displayName` in form data when explicitly set in frontmatter, instead of always generating one from the slug.
- **Server**: All 5 HTTP publish handlers now skip `validateDisplayName` when empty, letting the mutation's `resolveDisplayName` handle fallback to the existing value.

## Test plan
- [ ] Upload a new skill via GUI — display name should auto-populate from slug
- [ ] Update an existing skill via GUI (GitHub import) with no displayName in frontmatter — should preserve existing display name
- [ ] Update via CLI without displayName in frontmatter — should preserve existing display name
- [ ] Publish with explicit displayName in frontmatter — should use the provided value

🤖 Generated with [Claude Code](https://claude.com/claude-code)