### PR TITLE
Populate display name from existing record on update

### DIFF
--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { api } from "../../convex/_generated/api";
 import { useSEO } from "../lib/useSEO";
 import { parseFrontmatter } from "../lib/parseFrontmatter";
@@ -130,6 +130,13 @@ function UploadPage() {
   const isOwnedByOther = !!(existing && currentUser && existing.ownerUserId !== currentUser._id);
   const isUpdate = !!existing && !isOwnedByOther;
 
+  // When we detect this is an update, populate displayName from the existing record
+  useEffect(() => {
+    if (isUpdate && existing?.displayName) {
+      setDisplayName(existing.displayName);
+    }
+  }, [isUpdate, existing?.displayName]);
+
   const slugError = (() => {
     const s = slug.trim();
     if (!s) return null;
@@ -241,11 +248,11 @@ function UploadPage() {
           if (frontmatter.name && typeof frontmatter.name === "string") {
             setSlug(frontmatter.name);
             // Use explicit displayName from frontmatter if present;
-            // otherwise generate from slug only for new packages (not updates)
+            // otherwise generate from slug (useEffect will overwrite for updates)
             const fmDisplayName = frontmatter.displayName ?? frontmatter.display_name;
             if (typeof fmDisplayName === "string" && fmDisplayName.trim()) {
               setDisplayName(fmDisplayName.trim());
-            } else if (!updateSlug) {
+            } else {
               setDisplayName(
                 frontmatter.name
                   .split("-")
@@ -261,7 +268,7 @@ function UploadPage() {
         });
       }
     },
-    [kind, updateSlug],
+    [kind],
   );
 
   const handleDrop = useCallback(


### PR DESCRIPTION
## Summary
- Add `useEffect` that populates `displayName` from `existing.displayName` when `isUpdate` becomes true
- Simplify `processFiles` to always auto-generate displayName from slug (the `useEffect` corrects it for updates)
- Fixes the async timing issue: `processFiles` sets slug → query resolves → `existing` found → `useEffect` populates the correct display name

## Test plan
- [ ] GitHub import on existing package — display name field shows existing value, not title-cased slug
- [ ] GitHub import on new package — display name auto-generates from slug as before
- [ ] Manual file upload on existing package — display name populated from existing record
- [ ] User can still manually edit display name after it's populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)