### PR TITLE
Move dependencies above comments on detail pages

### DIFF
--- a/src/routes/roles.$slug.tsx
+++ b/src/routes/roles.$slug.tsx
@@ -329,14 +329,6 @@ function RoleDetailPage() {
         userId={currentUser?._id}
       />
 
-      {/* Comments */}
-      <CommentsSection
-        targetId={role._id}
-        targetKind="role"
-        commentCount={role.stats.comments}
-        currentUser={currentUser}
-      />
-
       {/* Skill Dependencies */}
       {role.dependencies.skills.length > 0 && (
         <div className="space-y-2">
@@ -378,6 +370,14 @@ function RoleDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Comments */}
+      <CommentsSection
+        targetId={role._id}
+        targetKind="role"
+        commentCount={role.stats.comments}
+        currentUser={currentUser}
+      />
     </div>
   );
 }

--- a/src/routes/skills.$slug.tsx
+++ b/src/routes/skills.$slug.tsx
@@ -378,14 +378,6 @@ function SkillDetailPage() {
         userId={currentUser?._id}
       />
 
-      {/* Comments */}
-      <CommentsSection
-        targetId={skill._id}
-        targetKind="skill"
-        commentCount={skill.stats.comments}
-        currentUser={currentUser}
-      />
-
       {/* Dependencies */}
       {skill.dependencies.skills.length > 0 && (
         <div className="space-y-2">
@@ -404,6 +396,14 @@ function SkillDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Comments */}
+      <CommentsSection
+        targetId={skill._id}
+        targetKind="skill"
+        commentCount={skill.stats.comments}
+        currentUser={currentUser}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Reorder skill and role detail pages to show dependencies section before comments
- Dependencies are more immediately useful than comments when browsing a package

## Test plan
- [ ] Skill detail page: dependencies appear above comments
- [ ] Role detail page: skill deps and role deps appear above comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)