### PR TITLE
Fix integration download count not tracking

### DIFF
--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -22,6 +22,7 @@ export const trackDownload = mutation({
     const table = args.targetKind === "skill" ? "skills"
       : args.targetKind === "role" ? "roles"
       : args.targetKind === "memory" ? "memories"
+      : args.targetKind === "integration" ? "integrations"
       : "agents";
     const target = await ctx.db
       .query(table)
@@ -53,6 +54,14 @@ export const trackDownload = mutation({
           .query("memoryVersions")
           .withIndex("by_memory_version", (q) =>
             q.eq("memoryId", target._id as any).eq("version", args.version!),
+          )
+          .first();
+        versionId = ver?._id;
+      } else if (args.targetKind === "integration") {
+        const ver = await ctx.db
+          .query("integrationVersions")
+          .withIndex("by_integration_version", (q) =>
+            q.eq("integrationId", target._id as any).eq("version", args.version!),
           )
           .first();
         versionId = ver?._id;


### PR DESCRIPTION
## Summary
- Integration downloads were silently falling through to the `agents` table because the `"integration"` kind was missing from the conditional chain in `convex/downloads.ts`
- Added the missing `"integration" → "integrations"` case to the table lookup
- Added the missing `integrationVersions` query branch for version resolution

## Test plan
- [ ] Publish an integration and verify download count increments after install
- [ ] Verify existing skill/role/agent/memory download tracking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)