### PR TITLE
Add project-scoped integration support to CLI

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -649,6 +649,13 @@ def install_memory(slug, is_global, skip_tools, yes, update, ver, force, save, s
 @install.command("integration")
 @click.argument("slug")
 @click.option(
+    "--global",
+    "is_global",
+    is_flag=True,
+    default=False,
+    help="Install to global directory (~/.strawpot or STRAWPOT_HOME)",
+)
+@click.option(
     "--skip-tools",
     is_flag=True,
     default=False,
@@ -679,23 +686,43 @@ def install_memory(slug, is_global, skip_tools, yes, update, ver, force, save, s
     default=False,
     help="With --version, force replace an existing installation",
 )
-def install_integration(slug, skip_tools, yes, update, ver, force):
-    """Install an integration (always global)."""
+@click.option(
+    "--save",
+    is_flag=True,
+    default=False,
+    help="Save dependency to strawpot.toml with ^X.Y.Z constraint",
+)
+@click.option(
+    "--save-exact",
+    is_flag=True,
+    default=False,
+    help="Save dependency to strawpot.toml with ==X.Y.Z constraint",
+)
+def install_integration(slug, is_global, skip_tools, yes, update, ver, force, save, save_exact):
+    """Install an integration."""
     if force and not ver:
         print_error("--force requires --version")
         raise SystemExit(1)
     if update and ver:
         print_error("--update and --version cannot be used together")
         raise SystemExit(1)
+    if save and save_exact:
+        print_error("--save and --save-exact cannot be used together")
+        raise SystemExit(1)
+    if (save or save_exact) and is_global:
+        print_error("--save/--save-exact cannot be used with --global")
+        raise SystemExit(1)
     _install_impl(
         slug,
         kind="integration",
-        is_global=True,
+        is_global=is_global,
         skip_tools=skip_tools,
         yes=yes,
         update=update,
         version=ver,
         force=force,
+        save=save,
+        save_exact=save_exact,
     )
 
 

--- a/cli/src/strawhub/commands/uninstall.py
+++ b/cli/src/strawhub/commands/uninstall.py
@@ -120,9 +120,11 @@ def uninstall_memory(slug, ver, is_global, save):
 @uninstall.command("integration")
 @click.argument("slug")
 @click.option("--version", "ver", default=None, help="Specific version to remove (removes all versions if omitted)")
-def uninstall_integration(slug, ver):
-    """Remove an installed integration (always global)."""
-    _uninstall_impl(slug, kind="integration", ver=ver, is_global=True)
+@click.option("--global", "is_global", is_flag=True, default=False, help="Remove from global directory (~/.strawpot or STRAWPOT_HOME)")
+@click.option("--save", is_flag=True, default=False, help="Also remove from strawpot.toml")
+def uninstall_integration(slug, ver, is_global, save):
+    """Remove an installed integration."""
+    _uninstall_impl(slug, kind="integration", ver=ver, is_global=is_global, save=save)
 
 
 def _find_targets(

--- a/cli/src/strawhub/commands/update.py
+++ b/cli/src/strawhub/commands/update.py
@@ -163,7 +163,9 @@ def update_memory(slug, is_global, yes, save):
 
 @update.command("integration")
 @click.argument("slug")
+@click.option("--global", "is_global", is_flag=True, default=False, help="Update global packages (~/.strawpot or STRAWPOT_HOME)")
 @click.option("--yes", "-y", is_flag=True, default=False, help="Automatically confirm tool install commands without prompting")
-def update_integration(slug, yes):
-    """Update an installed integration to its latest version (always global)."""
-    _update_one_impl(slug, kind="integration", is_global=True, yes=yes)
+@click.option("--save", is_flag=True, default=False, help="Update version constraint in strawpot.toml")
+def update_integration(slug, is_global, yes, save):
+    """Update an installed integration to its latest version."""
+    _update_one_impl(slug, kind="integration", is_global=is_global, yes=yes, save=save)

--- a/cli/src/strawhub/project_file.py
+++ b/cli/src/strawhub/project_file.py
@@ -11,6 +11,15 @@ The project file declares dependencies with optional version constraints:
     implementer = "*"
     reviewer = "==2.0.0"
 
+    [agents]
+    my-agent = "*"
+
+    [memories]
+    shared-context = "==1.0.0"
+
+    [integrations]
+    discord = "*"
+
 Constraint formats:
     "*"       — latest version
     "==X.Y.Z" — exact version
@@ -30,10 +39,15 @@ else:
 class ProjectFile:
     """Manages the strawpot.toml project file."""
 
+    _SECTIONS = ("skills", "roles", "agents", "memories", "integrations")
+
     def __init__(self, path: Path):
         self.path = path
         self.skills: dict[str, str] = {}
         self.roles: dict[str, str] = {}
+        self.agents: dict[str, str] = {}
+        self.memories: dict[str, str] = {}
+        self.integrations: dict[str, str] = {}
 
     @classmethod
     def load(cls, path: Path) -> ProjectFile:
@@ -43,8 +57,8 @@ class ProjectFile:
             return pf
         with open(path, "rb") as f:
             data = tomllib.load(f)
-        pf.skills = {k: str(v) for k, v in data.get("skills", {}).items()}
-        pf.roles = {k: str(v) for k, v in data.get("roles", {}).items()}
+        for section in cls._SECTIONS:
+            setattr(pf, section, {k: str(v) for k, v in data.get(section, {}).items()})
         return pf
 
     @classmethod
@@ -57,25 +71,35 @@ class ProjectFile:
     def save(self) -> None:
         """Write project file to disk."""
         lines: list[str] = []
-        if self.skills:
-            lines.append("[skills]")
-            for slug in sorted(self.skills):
-                lines.append(f'{slug} = "{self.skills[slug]}"')
-            lines.append("")
-        if self.roles:
-            lines.append("[roles]")
-            for slug in sorted(self.roles):
-                lines.append(f'{slug} = "{self.roles[slug]}"')
-            lines.append("")
+        for section in self._SECTIONS:
+            entries: dict[str, str] = getattr(self, section)
+            if entries:
+                lines.append(f"[{section}]")
+                for slug in sorted(entries):
+                    lines.append(f'{slug} = "{entries[slug]}"')
+                lines.append("")
         self.path.write_text("\n".join(lines), encoding="utf-8")
+
+    # Map kind → attribute name (handles irregular plural "memory" → "memories")
+    _KIND_TO_SECTION = {
+        "skill": "skills",
+        "role": "roles",
+        "agent": "agents",
+        "memory": "memories",
+        "integration": "integrations",
+    }
+
+    def _target(self, kind: str) -> dict[str, str]:
+        """Return the dict for the given package kind."""
+        section = self._KIND_TO_SECTION[kind]
+        return getattr(self, section)
 
     def add_dependency(
         self, kind: str, slug: str, version: str, exact: bool = False
     ) -> None:
         """Add or update a dependency with a version constraint."""
         constraint = f"=={version}" if exact else "*"
-        target = self.skills if kind == "skill" else self.roles
-        target[slug] = constraint
+        self._target(kind)[slug] = constraint
 
     def update_dependency(self, kind: str, slug: str, new_version: str) -> bool:
         """Update the version in an existing constraint, preserving the operator.
@@ -85,7 +109,7 @@ class ProjectFile:
 
         Returns True if the dependency existed and was updated.
         """
-        target = self.skills if kind == "skill" else self.roles
+        target = self._target(kind)
         if slug not in target:
             return False
         current = target[slug]
@@ -99,31 +123,34 @@ class ProjectFile:
 
     def get_constraint(self, kind: str, slug: str) -> str | None:
         """Get the constraint string for a dependency, or None."""
-        target = self.skills if kind == "skill" else self.roles
+        target = self._target(kind)
         return target.get(slug)
 
     def remove_dependency(self, kind: str, slug: str) -> bool:
         """Remove a dependency. Returns True if it was present."""
-        target = self.skills if kind == "skill" else self.roles
+        target = self._target(kind)
         if slug in target:
             del target[slug]
             return True
         return False
 
+    # Reverse map: section name → kind
+    _SECTION_TO_KIND = {v: k for k, v in _KIND_TO_SECTION.items()}
+
     def get_all_dependencies(self) -> list[tuple[str, str, str]]:
         """Return all dependencies as (kind, slug, constraint) tuples."""
         deps: list[tuple[str, str, str]] = []
-        for slug, constraint in self.skills.items():
-            deps.append(("skill", slug, constraint))
-        for slug, constraint in self.roles.items():
-            deps.append(("role", slug, constraint))
+        for section in self._SECTIONS:
+            kind = self._SECTION_TO_KIND[section]
+            for slug, constraint in getattr(self, section).items():
+                deps.append((kind, slug, constraint))
         return deps
 
     def has_dependency(self, kind: str, slug: str) -> bool:
         """Check if a dependency is declared."""
-        target = self.skills if kind == "skill" else self.roles
+        target = self._target(kind)
         return slug in target
 
     @property
     def is_empty(self) -> bool:
-        return not self.skills and not self.roles
+        return all(not getattr(self, s) for s in self._SECTIONS)

--- a/cli/tests/test_uninstall.py
+++ b/cli/tests/test_uninstall.py
@@ -96,17 +96,23 @@ class TestUninstallImpl:
                 _uninstall_impl("dep", kind="skill", ver=None, is_global=False)
             assert exc_info.value.code == 1
 
-    def test_integration_always_global(self):
-        """Verify uninstall integration uses is_global=True."""
+    def test_integration_defaults_to_local(self):
+        """Verify uninstall integration defaults to is_global=False."""
         runner = CliRunner()
         with patch("strawhub.commands.uninstall._uninstall_impl") as mock_impl:
             result = runner.invoke(cli, ["uninstall", "integration", "test-slug"])
 
         mock_impl.assert_called_once()
-        call_kwargs = mock_impl.call_args
-        assert call_kwargs.kwargs.get("is_global") is True or (
-            len(call_kwargs.args) > 3 and call_kwargs.args[3] is True
-        )
+        assert mock_impl.call_args.kwargs.get("is_global") is False
+
+    def test_integration_global_flag(self):
+        """Verify uninstall integration --global passes is_global=True."""
+        runner = CliRunner()
+        with patch("strawhub.commands.uninstall._uninstall_impl") as mock_impl:
+            result = runner.invoke(cli, ["uninstall", "integration", "test-slug", "--global"])
+
+        mock_impl.assert_called_once()
+        assert mock_impl.call_args.kwargs.get("is_global") is True
 
     def test_save_removes_from_toml(self, tmp_path):
         """Verify --save calls ProjectFile.remove_dependency."""


### PR DESCRIPTION
## Summary
- Remove hardcoded `is_global=True` from `install_integration`, `uninstall_integration`, and `update_integration` commands — add `--global`, `--save`, `--save-exact` flags matching the pattern used by skill/role/agent/memory commands
- Add `[agents]`, `[memories]`, and `[integrations]` sections to `ProjectFile` (strawpot.toml), extending it from 2 resource types (skills, roles) to all 5
- Refactor `ProjectFile` internals to use `_SECTIONS` tuple, `_KIND_TO_SECTION` map, and `_target()` helper for DRY kind→dict resolution

## Test plan
- [x] All 301 existing CLI tests pass
- [x] Updated `test_integration_always_global` → `test_integration_defaults_to_local` + `test_integration_global_flag`
- [ ] Manual: `strawhub install integration discord` installs locally (default)
- [ ] Manual: `strawhub install integration discord --global` installs globally
- [ ] Manual: `strawhub install integration discord --save` records in strawpot.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)