### PR TITLE
Strip inline YAML comments from dependency specifiers

### DIFF
--- a/cli/src/strawhub/version_spec.py
+++ b/cli/src/strawhub/version_spec.py
@@ -42,6 +42,9 @@ def parse_dependency_spec(spec: str) -> DependencySpec:
     # Strip surrounding quotes that some YAML parsers may preserve
     if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
         s = s[1:-1]
+    # Strip inline YAML comments (e.g. "slug  # some note")
+    if "#" in s:
+        s = s[: s.index("#")].strip()
 
     if s == "*":
         return DependencySpec(slug="*", operator="wildcard", version=None)

--- a/cli/tests/test_version_spec.py
+++ b/cli/tests/test_version_spec.py
@@ -56,6 +56,14 @@ class TestParseDependencySpec:
     def test_wildcard(self):
         assert parse_dependency_spec("*") == DependencySpec("*", "wildcard", None)
 
+    def test_strips_inline_comments(self):
+        assert parse_dependency_spec("strawpot-ceo  # escalation target") == DependencySpec(
+            "strawpot-ceo", "latest", None
+        )
+        assert parse_dependency_spec("code-review==1.0.0 # pinned") == DependencySpec(
+            "code-review", "==", "1.0.0"
+        )
+
     def test_strips_surrounding_quotes(self):
         assert parse_dependency_spec('"*"') == DependencySpec("*", "wildcard", None)
         assert parse_dependency_spec("'git-workflow'") == DependencySpec(

--- a/convex/lib/versionSpec.test.ts
+++ b/convex/lib/versionSpec.test.ts
@@ -72,6 +72,19 @@ describe("parseDependencySpec", () => {
     });
   });
 
+  it("strips inline comments", () => {
+    expect(parseDependencySpec("strawpot-ceo  # escalation target")).toEqual({
+      slug: "strawpot-ceo",
+      operator: "latest",
+      version: null,
+    });
+    expect(parseDependencySpec("code-review==1.0.0 # pinned")).toEqual({
+      slug: "code-review",
+      operator: "==",
+      version: "1.0.0",
+    });
+  });
+
   it("strips surrounding quotes", () => {
     expect(parseDependencySpec('"*"')).toEqual({
       slug: "*",

--- a/convex/lib/versionSpec.ts
+++ b/convex/lib/versionSpec.ts
@@ -34,6 +34,11 @@ export function parseDependencySpec(spec: string): DependencySpec {
   if ((input.startsWith('"') && input.endsWith('"')) || (input.startsWith("'") && input.endsWith("'"))) {
     input = input.slice(1, -1);
   }
+  // Strip inline YAML comments (e.g. "slug  # some note")
+  const commentIdx = input.indexOf("#");
+  if (commentIdx >= 0) {
+    input = input.slice(0, commentIdx).trim();
+  }
 
   if (input === "*") {
     return { slug: "*", operator: "wildcard", version: null };

--- a/src/lib/versionSpec.test.ts
+++ b/src/lib/versionSpec.test.ts
@@ -46,6 +46,19 @@ describe("parseDependencySpec", () => {
     expect(spec.slug).toBe("my-skill");
   });
 
+  it("strips inline comments", () => {
+    const spec = parseDependencySpec("strawpot-ceo  # escalation target");
+    expect(spec.slug).toBe("strawpot-ceo");
+    expect(spec.operator).toBe("latest");
+  });
+
+  it("strips inline comment from versioned spec", () => {
+    const spec = parseDependencySpec("code-review==1.0.0 # pinned");
+    expect(spec.slug).toBe("code-review");
+    expect(spec.operator).toBe("==");
+    expect(spec.version).toBe("1.0.0");
+  });
+
   it("throws on invalid spec", () => {
     expect(() => parseDependencySpec("INVALID_SLUG")).toThrow();
     expect(() => parseDependencySpec("has spaces")).toThrow();

--- a/src/lib/versionSpec.ts
+++ b/src/lib/versionSpec.ts
@@ -25,6 +25,11 @@ export function parseDependencySpec(spec: string): DependencySpec {
   if ((input.startsWith('"') && input.endsWith('"')) || (input.startsWith("'") && input.endsWith("'"))) {
     input = input.slice(1, -1);
   }
+  // Strip inline YAML comments (e.g. "slug  # some note")
+  const commentIdx = input.indexOf("#");
+  if (commentIdx >= 0) {
+    input = input.slice(0, commentIdx).trim();
+  }
 
   if (input === "*") {
     return { slug: "*", operator: "wildcard", version: null };


### PR DESCRIPTION
## Summary
- Dependency strings with inline YAML comments (e.g. `strawpot-ceo  # escalation target`) were causing `parseDependencySpec` to throw "Invalid dependency specifier", surfaced to users as a raw Convex server error
- Strip `#` comments before parsing in all three layers: server (`convex/lib/versionSpec.ts`), client (`src/lib/versionSpec.ts`), and CLI (`cli/src/strawhub/version_spec.py`)
- Added tests for comment stripping in all three test suites

## Test plan
- [x] All TypeScript tests pass (45 tests)
- [x] All Python tests pass (38 tests)
- [ ] Verify publishing a role with commented dependencies succeeds via GitHub import

🤖 Generated with [Claude Code](https://claude.com/claude-code)