### PR TITLE
Fix circular dependency resolution (closes #163)

### DIFF
--- a/cli/src/strawhub/resolver.py
+++ b/cli/src/strawhub/resolver.py
@@ -100,9 +100,7 @@ def resolve(
         if key in resolved:
             return
         if key in visiting:
-            raise DependencyError(
-                f"Circular dependency detected: {pkg_kind} '{pkg_slug}'"
-            )
+            return  # circular dep — node is being resolved up the stack
         visiting.add(key)
 
         pkg_candidates = index.get(key, [])

--- a/cli/tests/test_resolver.py
+++ b/cli/tests/test_resolver.py
@@ -171,8 +171,8 @@ class TestResolveErrors:
                 local_root=strawpot_dir, global_root=strawpot_dir,
             )
 
-    def test_circular_dependency(self, strawpot_dir):
-        """Two skills that depend on each other."""
+    def test_circular_dependency_resolves(self, strawpot_dir):
+        """Two skills that depend on each other should resolve successfully."""
         d = strawpot_dir / "skills" / "a"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
@@ -187,11 +187,13 @@ class TestResolveErrors:
         )
         (d / ".version").write_text("1.0.0\n")
 
-        with pytest.raises(DependencyError, match="Circular dependency"):
-            resolve(
-                "a", kind="skill",
-                local_root=strawpot_dir, global_root=strawpot_dir,
-            )
+        result = resolve(
+            "a", kind="skill",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        assert result["slug"] == "a"
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert dep_slugs == {"b"}
 
     def test_kind_required(self, strawpot_dir, make_skill):
         """kind is a required argument."""
@@ -270,3 +272,59 @@ class TestResolveRoleDeps:
         assert "*" not in dep_slugs
         assert "reviewer" in dep_slugs
         assert "testing" in dep_slugs
+
+
+class TestCircularDependencies:
+    """Circular dependencies should resolve gracefully, not error."""
+
+    def test_two_roles_circular(self, strawpot_dir, make_role):
+        """Role A ↔ Role B (the design-system-architect ↔ visual-qa-reviewer case)."""
+        make_role("design-system-architect", "1.0.0", role_deps=["visual-qa-reviewer"])
+        make_role("visual-qa-reviewer", "1.0.0", role_deps=["design-system-architect"])
+
+        result = resolve(
+            "design-system-architect", kind="role",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        assert result["slug"] == "design-system-architect"
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert dep_slugs == {"visual-qa-reviewer"}
+
+    def test_three_way_cycle(self, strawpot_dir, make_skill):
+        """A → B → C → A."""
+        make_skill("a", "1.0.0", deps=["b"])
+        make_skill("b", "1.0.0", deps=["c"])
+        make_skill("c", "1.0.0", deps=["a"])
+
+        result = resolve(
+            "a", kind="skill",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        assert result["slug"] == "a"
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert dep_slugs == {"b", "c"}
+
+    def test_circular_with_shared_deps(self, strawpot_dir, make_skill, make_role):
+        """Roles A ↔ B, both depending on skill S."""
+        make_skill("shared-skill", "1.0.0")
+        make_role("role-a", "1.0.0", skill_deps=["shared-skill"], role_deps=["role-b"])
+        make_role("role-b", "1.0.0", skill_deps=["shared-skill"], role_deps=["role-a"])
+
+        result = resolve(
+            "role-a", kind="role",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        assert result["slug"] == "role-a"
+        dep_slugs = {d["slug"] for d in result["dependencies"]}
+        assert dep_slugs == {"role-b", "shared-skill"}
+
+    def test_self_dependency(self, strawpot_dir, make_skill):
+        """A skill that depends on itself."""
+        make_skill("self-dep", "1.0.0", deps=["self-dep"])
+
+        result = resolve(
+            "self-dep", kind="skill",
+            local_root=strawpot_dir, global_root=strawpot_dir,
+        )
+        assert result["slug"] == "self-dep"
+        assert result["dependencies"] == []

--- a/convex/httpApiV1/rolesV1.ts
+++ b/convex/httpApiV1/rolesV1.ts
@@ -120,9 +120,7 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
     if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `skill:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
-    if (visiting.has(key)) {
-      throw new Error(`Circular dependency: ${spec.slug}`);
-    }
+    if (visiting.has(key)) return; // circular dep — node is being resolved up the stack
     visiting.add(key);
 
     const skill = await ctx.runQuery(api.skills.getBySlug, { slug: spec.slug });
@@ -164,9 +162,7 @@ export async function handleResolveRoleDeps(ctx: any, request: Request): Promise
     if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `role:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
-    if (visiting.has(key)) {
-      throw new Error(`Circular dependency: ${spec.slug}`);
-    }
+    if (visiting.has(key)) return; // circular dep — node is being resolved up the stack
     visiting.add(key);
 
     const depRole = await ctx.runQuery(api.roles.getBySlug, { slug: spec.slug });

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -121,9 +121,7 @@ export async function handleResolveSkillDeps(ctx: any, request: Request): Promis
     if (spec.operator === "wildcard") return; // "*" is not a real package
     const key = `skill:${spec.slug}`;
     if (resolvedKeys.has(key)) return;
-    if (visiting.has(key)) {
-      throw new Error(`Circular dependency: ${spec.slug}`);
-    }
+    if (visiting.has(key)) return; // circular dep — node is being resolved up the stack
     visiting.add(key);
 
     const depSkill = await ctx.runQuery(api.skills.getBySlug, { slug: spec.slug });


### PR DESCRIPTION
## Summary
- When two packages depend on each other (e.g., `design-system-architect` ↔ `visual-qa-reviewer`), `strawpot install` failed with "Circular dependency" error
- Root cause: DFS dependency resolution in both CLI resolver and server-side API threw errors on cycles instead of handling them gracefully
- Fix: when a node is already being visited (cycle detected), skip it instead of erroring — the node will be fully resolved when the call stack unwinds
- Applied to all 3 resolution paths: CLI `resolver.py`, server `rolesV1.ts` (both `resolveSkill` and `resolveRole`), and server `skillsV1.ts`

## Test plan
- [x] Updated existing circular dependency test to verify resolution succeeds
- [x] Added 4 new regression tests: mutual role deps, 3-way cycle, circular with shared deps, self-dependency
- [x] All 305 CLI tests pass
- [x] Verified the exact `design-system-architect` ↔ `visual-qa-reviewer` scenario works

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)