### PR TITLE
Fix extract_tools crash on packages with empty metadata (closes #164)

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -267,29 +267,53 @@ def _install_impl(
             # Run package install scripts (non-fatal)
             if not skip_tools:
                 for dep in installed_deps:
-                    run_package_install(
-                        root, dep["kind"], dep["slug"], yes=yes
+                    try:
+                        run_package_install(
+                            root, dep["kind"], dep["slug"], yes=yes
+                        )
+                    except Exception as e:
+                        console.print(
+                            f"[yellow]Warning:[/yellow] Install script for "
+                            f"'{dep['slug']}' failed: {e}"
+                        )
+                try:
+                    run_package_install(root, kind, slug, yes=yes)
+                except Exception as e:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] Install script for "
+                        f"'{slug}' failed: {e}"
                     )
-                run_package_install(root, kind, slug, yes=yes)
 
             # Run tool installs (non-fatal)
             if not skip_tools:
                 seen: set[str] = set()
                 all_results: list[dict] = []
                 for dep in installed_deps:
+                    try:
+                        results = run_tool_installs_for_package(
+                            root,
+                            dep["kind"],
+                            dep["slug"],
+                            dep["version"],
+                            yes=yes,
+                            seen=seen,
+                        )
+                        all_results.extend(results)
+                    except Exception as e:
+                        console.print(
+                            f"[yellow]Warning:[/yellow] Tool check for "
+                            f"'{dep['slug']}' failed: {e}"
+                        )
+                try:
                     results = run_tool_installs_for_package(
-                        root,
-                        dep["kind"],
-                        dep["slug"],
-                        dep["version"],
-                        yes=yes,
-                        seen=seen,
+                        root, kind, slug, target_version, yes=yes, seen=seen
                     )
                     all_results.extend(results)
-                results = run_tool_installs_for_package(
-                    root, kind, slug, target_version, yes=yes, seen=seen
-                )
-                all_results.extend(results)
+                except Exception as e:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] Tool check for "
+                        f"'{slug}' failed: {e}"
+                    )
                 failed = [r for r in all_results if r["status"] == "failed"]
                 if failed:
                     names = ", ".join(r["tool"] for r in failed)

--- a/cli/src/strawhub/tools.py
+++ b/cli/src/strawhub/tools.py
@@ -55,11 +55,13 @@ def extract_tools(fm: dict) -> dict | None:
     Reads from metadata.strawpot.tools.
     Returns the tools dict or None if not present.
     """
-    tools = (
-        fm.get("metadata", {})
-        .get("strawpot", {})
-        .get("tools")
-    )
+    metadata = fm.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    strawpot = metadata.get("strawpot")
+    if not isinstance(strawpot, dict):
+        return None
+    tools = strawpot.get("tools")
     if not isinstance(tools, dict) or not tools:
         return None
     return tools

--- a/cli/tests/test_tools.py
+++ b/cli/tests/test_tools.py
@@ -86,6 +86,20 @@ class TestExtractTools:
         fm = {"metadata": {"strawpot": {"tools": "invalid"}}}
         assert extract_tools(fm) is None
 
+    def test_returns_none_when_metadata_is_empty_string(self):
+        """Regression: custom parser returns '' for empty YAML values."""
+        assert extract_tools({"metadata": ""}) is None
+
+    def test_returns_none_when_strawpot_is_empty_string(self):
+        """Regression: 'metadata:\n  strawpot:' with no content yields ''."""
+        assert extract_tools({"metadata": {"strawpot": ""}}) is None
+
+    def test_returns_none_when_metadata_is_list(self):
+        assert extract_tools({"metadata": ["a", "b"]}) is None
+
+    def test_returns_none_when_strawpot_is_list(self):
+        assert extract_tools({"metadata": {"strawpot": ["a"]}}) is None
+
 
 # ── parse_tool_specs ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Root cause:** `extract_tools()` used unsafe chained `.get()` that threw `AttributeError` when `metadata` or `strawpot` was an empty string (`""`) — the custom YAML parser returns `""` for empty values like `metadata:\n  strawpot:`. This was the same bug fixed in `extract_dependencies()` and `run_package_install()` in commit d7eaaec (#129) but `extract_tools()` was missed.
- **Fix 1:** Replaced chained `.get()` with step-by-step extraction with `isinstance(dict)` checks, consistent with the defensive pattern used in `extract_dependencies()` and `run_package_install()`.
- **Fix 2:** Wrapped the post-install section in `_install_impl()` with `try/except` to make it actually non-fatal (matching its comment). Previously any unexpected exception from tool extraction would crash the entire install with a confusing traceback despite files already being written.

## Test plan

- [x] 4 new regression tests for `extract_tools` covering empty string metadata, empty string strawpot, list metadata, and list strawpot
- [x] All 310 existing tests pass — no regressions
- [x] Verified the exact crash scenario (`extract_tools({"metadata": ""})`) no longer throws `AttributeError`

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)