### PR TITLE
Add persistent operation logging to CLI

### DIFF
--- a/cli/src/strawhub/commands/install.py
+++ b/cli/src/strawhub/commands/install.py
@@ -6,6 +6,7 @@ import click
 from strawhub.client import StrawHubClient
 from strawhub.display import print_success, print_error, console
 from strawhub.errors import NotFoundError, StrawHubError, DependencyError
+from strawhub.logging import log_operation, log_exception
 from strawhub.lockfile import Lockfile, PackageRef
 from strawhub.paths import (
     get_root,
@@ -253,6 +254,13 @@ def _install_impl(
 
             lockfile.save()
             print_success(f"Installed {kind} '{slug}' v{target_version}")
+            log_operation(
+                operation="install",
+                kind=kind,
+                slug=slug,
+                version=target_version,
+                status="success",
+            )
 
             # Save to project file if requested
             if save or save_exact:
@@ -322,11 +330,17 @@ def _install_impl(
                         f"{names}. Run 'strawhub install-tools' to retry."
                     )
 
-        except NotFoundError:
+        except NotFoundError as e:
             print_error(f"'{slug}' not found.")
+            log_exception(
+                operation="install", kind=kind, slug=slug, version=version, exc=e,
+            )
             raise SystemExit(1)
         except (StrawHubError, DependencyError) as e:
             print_error(str(e))
+            log_exception(
+                operation="install", kind=kind, slug=slug, version=version, exc=e,
+            )
             raise SystemExit(1)
 
 

--- a/cli/src/strawhub/commands/publish.py
+++ b/cli/src/strawhub/commands/publish.py
@@ -6,6 +6,7 @@ import click
 from strawhub.client import StrawHubClient
 from strawhub.display import print_success, print_error, console
 from strawhub.errors import StrawHubError
+from strawhub.logging import log_operation, log_exception
 from strawhub.frontmatter import parse_frontmatter, extract_dependencies, rewrite_frontmatter_name
 
 
@@ -113,11 +114,20 @@ def _publish_impl(path, kind, ver, changelog, tags):
                 result = client.publish_integration(form_data, files)
             else:
                 result = client.publish_agent(form_data, files)
-            print_success(
-                f"Published {kind} '{slug}' v{result.get('version', version)}"
+            published_version = result.get("version", version)
+            print_success(f"Published {kind} '{slug}' v{published_version}")
+            log_operation(
+                operation="publish",
+                kind=kind,
+                slug=slug,
+                version=published_version,
+                status="success",
             )
         except StrawHubError as e:
             print_error(str(e))
+            log_exception(
+                operation="publish", kind=kind, slug=slug, version=version, exc=e,
+            )
             raise SystemExit(1)
 
 

--- a/cli/src/strawhub/commands/uninstall.py
+++ b/cli/src/strawhub/commands/uninstall.py
@@ -4,6 +4,7 @@ import click
 
 from strawhub.display import print_success, print_error, console
 from strawhub.lockfile import Lockfile, PackageRef
+from strawhub.logging import log_operation
 from strawhub.paths import (
     get_root,
     get_lockfile_path,
@@ -38,12 +39,20 @@ def _uninstall_impl(slug, kind, ver, is_global, save=False):
 
     if not lockfile.packages:
         print_error("No packages installed (lockfile is empty).")
+        log_operation(
+            operation="uninstall", kind=kind, slug=slug, version=ver,
+            status="failure", error="lockfile is empty",
+        )
         raise SystemExit(1)
 
     # Find matching direct installs
     targets = _find_targets(lockfile, slug, kind, ver)
     if not targets:
         print_error(f"'{slug}' is not a direct install. Nothing to remove.")
+        log_operation(
+            operation="uninstall", kind=kind, slug=slug, version=ver,
+            status="failure", error="not a direct install",
+        )
         raise SystemExit(1)
 
     # Remove each target from direct installs
@@ -75,6 +84,14 @@ def _uninstall_impl(slug, kind, ver, is_global, save=False):
             console.print(f"Removed '{slug}' from strawpot.toml")
 
     print_success("Uninstall complete.")
+    for ref in targets:
+        log_operation(
+            operation="uninstall",
+            kind=ref.kind,
+            slug=ref.slug,
+            version=ref.version,
+            status="success",
+        )
 
 
 @uninstall.command("skill")

--- a/cli/src/strawhub/logging.py
+++ b/cli/src/strawhub/logging.py
@@ -1,0 +1,140 @@
+"""Persistent operation logging for the StrawHub CLI.
+
+Writes structured log entries to $STRAWPOT_HOME/logs/operations.log
+using Python's logging module with rotating file handlers.
+"""
+
+import logging
+import traceback
+from logging.handlers import RotatingFileHandler
+
+from strawhub.paths import get_global_root
+
+_LOG_DIR_NAME = "logs"
+_LOG_FILE_NAME = "operations.log"
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_BACKUP_COUNT = 3
+_LOG_FORMAT = "%(asctime)s | %(levelname)s | %(message)s"
+_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+_logger: logging.Logger | None = None
+
+
+def get_logger() -> logging.Logger:
+    """Return the shared operations logger, creating it on first call.
+
+    The logger writes to ``$STRAWPOT_HOME/logs/operations.log`` with
+    rotation at 5 MB and 3 backup files.  If the log directory cannot
+    be created or written to, a :class:`logging.NullHandler` is used
+    instead so that callers never need to handle logging errors.
+    """
+    global _logger
+    if _logger is not None:
+        return _logger
+
+    _logger = logging.getLogger("strawhub.operations")
+    _logger.setLevel(logging.DEBUG)
+    # Prevent propagation to the root logger (avoid duplicate output).
+    _logger.propagate = False
+
+    try:
+        log_dir = get_global_root() / _LOG_DIR_NAME
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / _LOG_FILE_NAME
+
+        handler = RotatingFileHandler(
+            log_file,
+            maxBytes=_MAX_BYTES,
+            backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT))
+        _logger.addHandler(handler)
+    except Exception:
+        # Filesystem or config issue — fall back to a no-op handler.
+        _logger.addHandler(logging.NullHandler())
+
+    return _logger
+
+
+def reset_logger() -> None:
+    """Reset the cached logger.  Used by tests."""
+    global _logger
+    if _logger is not None:
+        for handler in list(_logger.handlers):
+            handler.close()
+            _logger.removeHandler(handler)
+    _logger = None
+
+
+def log_operation(
+    *,
+    operation: str,
+    kind: str,
+    slug: str,
+    version: str | None = None,
+    status: str,
+    error: str | None = None,
+) -> None:
+    """Log a CLI operation to the persistent log file.
+
+    Parameters
+    ----------
+    operation:
+        The operation name (``install``, ``uninstall``, ``update``,
+        ``publish``).
+    kind:
+        Resource kind (``skill``, ``role``, ``agent``, ``memory``,
+        ``integration``).
+    slug:
+        Resource slug.
+    version:
+        Resource version, if known.
+    status:
+        Outcome — ``success`` or ``failure``.
+    error:
+        Error description on failure.
+    """
+    try:
+        logger = get_logger()
+        ver_part = f" v{version}" if version else ""
+        msg = f"op={operation} kind={kind} slug={slug}{ver_part} status={status}"
+        if error:
+            escaped_error = error.replace("\n", "\\n")
+            msg += f" error={escaped_error}"
+
+        if status == "failure":
+            logger.error(msg)
+        else:
+            logger.info(msg)
+    except Exception:
+        pass  # Logging must never interrupt CLI operations
+
+
+def log_exception(
+    *,
+    operation: str,
+    kind: str,
+    slug: str,
+    version: str | None = None,
+    exc: BaseException,
+) -> None:
+    """Log an operation failure with a full traceback.
+
+    Convenience wrapper around :func:`log_operation` that formats the
+    exception and appends the traceback.
+    """
+    try:
+        tb = "".join(traceback.format_exception(exc))
+        error_detail = f"{exc}\n{tb}"
+        log_operation(
+            operation=operation,
+            kind=kind,
+            slug=slug,
+            version=version,
+            status="failure",
+            error=error_detail,
+        )
+    except Exception:
+        pass  # Logging must never interrupt CLI operations

--- a/cli/tests/test_logging.py
+++ b/cli/tests/test_logging.py
@@ -1,0 +1,175 @@
+"""Tests for strawhub.logging — persistent operation logging."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from strawhub.logging import (
+    get_logger,
+    log_exception,
+    log_operation,
+    reset_logger,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_logger():
+    """Reset the cached logger before and after every test."""
+    reset_logger()
+    yield
+    reset_logger()
+
+
+def _flush_handlers() -> None:
+    """Flush all handlers on the shared logger so log files are readable."""
+    for h in get_logger().handlers:
+        h.flush()
+
+
+class TestGetLogger:
+    def test_creates_log_file(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            logger = get_logger()
+            logger.info("hello")
+            _flush_handlers()
+
+        log_file = tmp_path / "logs" / "operations.log"
+        assert log_file.exists()
+        assert "hello" in log_file.read_text(encoding="utf-8")
+
+    def test_creates_log_directory(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            get_logger()
+        assert (tmp_path / "logs").is_dir()
+
+    def test_returns_same_instance(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            a = get_logger()
+            b = get_logger()
+        assert a is b
+
+    def test_falls_back_to_null_handler_on_os_error(self, tmp_path):
+        """If log directory cannot be created, a NullHandler is used."""
+        # Place a regular file where the logger expects to create a directory.
+        bad_root = tmp_path / "bad"
+        bad_root.mkdir()
+        (bad_root / "logs").write_text("block")
+
+        with patch("strawhub.logging.get_global_root", return_value=bad_root):
+            logger = get_logger()
+        # Should still work (NullHandler) — no exception.
+        logger.info("this goes nowhere")
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.NullHandler)
+
+
+class TestLogOperation:
+    def test_success_entry(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            log_operation(
+                operation="install",
+                kind="skill",
+                slug="git-workflow",
+                version="1.0.0",
+                status="success",
+            )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        assert "op=install" in content
+        assert "kind=skill" in content
+        assert "slug=git-workflow" in content
+        assert "v1.0.0" in content
+        assert "status=success" in content
+        assert "INFO" in content
+
+    def test_failure_entry_with_error(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            log_operation(
+                operation="install",
+                kind="role",
+                slug="reviewer",
+                version="2.0.0",
+                status="failure",
+                error="Not found",
+            )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        assert "status=failure" in content
+        assert "error=Not found" in content
+        assert "ERROR" in content
+
+    def test_missing_version(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            log_operation(
+                operation="uninstall",
+                kind="skill",
+                slug="foo",
+                status="success",
+            )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        assert "slug=foo" in content
+        # No version token when version is None.
+        assert " v" not in content.split("slug=foo")[1].split("status=")[0]
+
+
+    def test_newlines_in_error_are_escaped(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            log_operation(
+                operation="install",
+                kind="skill",
+                slug="bad",
+                status="failure",
+                error="line1\nline2\nline3",
+            )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        # The entire log entry should be a single line (newlines escaped).
+        log_lines = [l for l in content.strip().splitlines() if l.strip()]
+        assert len(log_lines) == 1
+        assert "line1\\nline2\\nline3" in content
+
+
+class TestLogException:
+    def test_includes_traceback(self, tmp_path):
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            try:
+                raise ValueError("boom")
+            except ValueError as exc:
+                log_exception(
+                    operation="publish",
+                    kind="role",
+                    slug="bad-role",
+                    version="0.1.0",
+                    exc=exc,
+                )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        assert "status=failure" in content
+        assert "boom" in content
+        assert "ValueError" in content
+        assert "Traceback" in content
+
+    def test_version_none(self, tmp_path):
+        """log_exception works when version is None (e.g. install without --version)."""
+        with patch("strawhub.logging.get_global_root", return_value=tmp_path):
+            try:
+                raise RuntimeError("oops")
+            except RuntimeError as exc:
+                log_exception(
+                    operation="install",
+                    kind="role",
+                    slug="my-role",
+                    exc=exc,
+                )
+            _flush_handlers()
+
+        content = (tmp_path / "logs" / "operations.log").read_text(encoding="utf-8")
+        assert "slug=my-role" in content
+        assert "oops" in content


### PR DESCRIPTION
## Summary

- Adds a new `strawhub.logging` module that writes structured log entries to `$STRAWPOT_HOME/logs/operations.log` using Python's `RotatingFileHandler` (5 MB max, 3 backups)
- Integrates logging into `install`, `uninstall`, and `publish` commands — both success and failure paths are recorded
- Logging is internally exception-safe (`try/except Exception: pass`) so it never interrupts CLI operations
- Multiline tracebacks are escaped to `\n` to keep one log entry per line
- Falls back to `NullHandler` when the log directory cannot be created (e.g., permission issues)

**Log format:** `2026-03-23T10:00:00 | INFO | op=install kind=skill slug=git-workflow v1.0.0 status=success`

## Test plan

- [x] 10 new tests in `test_logging.py` covering: log file creation, directory creation, singleton logger, NullHandler fallback, success/failure entries, missing version, newline escaping, traceback inclusion, version=None path
- [x] All 320 tests pass (310 existing + 10 new)
- [x] Reviewed by code-simplifier (removed unused imports, modernized traceback call)
- [x] Reviewed by pr-reviewer (3 must-fix issues addressed: exception safety, newline escaping, uninstall failure logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)