### PR TITLE
Remove Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Browse, install, and publish the roles, skills, agents, memories, and integratio
 
 <p align="center">
   <a href="https://github.com/strawpot/strawhub/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/strawpot/strawhub/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
-  <a href="https://discord.gg/2BRsCRUrKb"><img src="https://img.shields.io/discord/1476285531464929505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -139,4 +139,3 @@ Settings can also be persisted in `~/.config/strawhub/config.json`.
 
 - **Registry**: <https://strawhub.dev>
 - **Source**: <https://github.com/strawpot/strawhub>
-- **Discord**: <https://discord.gg/2BRsCRUrKb>

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
 Homepage = "https://strawhub.dev"
 Repository = "https://github.com/strawpot/strawhub"
 Documentation = "https://github.com/strawpot/strawhub/blob/main/docs/http-api.md"
-Discord = "https://discord.gg/2BRsCRUrKb"
 
 [project.scripts]
 strawhub = "strawhub.cli:cli"


### PR DESCRIPTION
## Summary
- Remove Discord invite badge from root `README.md`
- Remove Discord community link from `cli/README.md` Links section
- Remove Discord URL from `cli/pyproject.toml` project URLs

Discord product code (`project_file.py` discord package entry) is intentionally unchanged — only community/invite links (discord.gg) were removed.

## Test plan
- [ ] Verify README badge row renders correctly without the Discord badge
- [ ] Verify `cli/README.md` links section is clean
- [ ] Verify `pip install` metadata no longer includes Discord URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)