### PR TITLE
chore: update license from MIT to Elastic License 2.0 (ELv2)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,7 +52,7 @@ Everything needed to create, validate, and install packages locally:
 - **File constraints** — Max 100 files, 10 MB each, 50 MB total. Slug format: lowercase alphanumeric + hyphens, max 64 chars. Semver versioning.
 - **CLI** — `strawhub validate` checks a package locally. `strawhub install` / `publish` / `resolve` work against any registry endpoint (override via `STRAWHUB_API_URL`).
 
-The format and CLI are MIT-licensed. Anyone can build tools that produce or consume StrawHub packages without depending on strawhub.dev.
+The format and CLI are licensed under the Elastic License 2.0 (ELv2). Anyone can build tools that produce or consume StrawHub packages without depending on strawhub.dev.
 
 ### Hosted layer (strawhub.dev)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,93 @@
-MIT License
+Elastic License 2.0 (ELv2)
 
-Copyright (c) 2026 Chris La
+URL: https://www.elastic.co/licensing/elastic-license
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+By using the software, you agree to all of the terms and conditions below.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject
+to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set
+of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's trademarks
+is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company
+makes such a claim, your patent license ends immediately for work on behalf
+of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license
+no later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your
+licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is Chris La, the entity offering these terms.
+
+The **software** is the software the licensor makes available under these
+terms, including any portion of it.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or
+the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your
+licenses.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Browse, install, and publish the roles, skills, agents, memories, and integratio
 
 <p align="center">
   <a href="https://github.com/strawpot/strawhub/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/strawpot/strawhub/ci.yml?branch=main&style=for-the-badge" alt="CI"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Elastic--2.0-blue.svg?style=for-the-badge" alt="Elastic License 2.0"></a>
 </p>
 
 ```
@@ -215,7 +215,7 @@ User task → StrawPot runtime → Role (ai-ceo)
 
 ## License
 
-[MIT](LICENSE)
+[Elastic License 2.0 (ELv2)](LICENSE)
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/strawpot/strawhub/ci.yml?branch=main)](https://github.com/strawpot/strawhub/actions/workflows/ci.yml?branch=main)
 [![PyPI](https://img.shields.io/pypi/v/strawhub)](https://pypi.org/project/strawhub/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/strawpot/strawhub/blob/main/LICENSE)
+[![License: Elastic-2.0](https://img.shields.io/badge/License-Elastic--2.0-blue.svg)](https://github.com/strawpot/strawhub/blob/main/LICENSE)
 
 Command-line client for [StrawHub](https://strawhub.dev), the public registry for [StrawPot](https://strawpot.com) agents.
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -3,7 +3,7 @@ name = "strawhub"
 dynamic = ["version"]
 description = "CLI for the StrawHub agent skill and role registry"
 readme = "README.md"
-license = "MIT"
+license = "Elastic-2.0"
 requires-python = ">=3.10"
 authors = [{ name = "StrawPot" }]
 keywords = ["strawhub", "strawpot", "agent", "skills", "roles", "registry", "cli"]
@@ -11,7 +11,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Replace MIT license with the full Elastic License 2.0 (ELv2) text in the LICENSE file (licensor: Chris La)
- Update license badge in README.md and cli/README.md to show Elastic-2.0
- Update pyproject.toml license field and classifier
- Update DESIGN.md license reference

## Test plan
- [ ] Verify LICENSE file contains the complete ELv2 text
- [ ] Verify README badges render correctly with "Elastic-2.0" label
- [ ] Verify pyproject.toml builds without errors with new license field

🤖 Generated with [Claude Code](https://claude.com/claude-code)