### PR TITLE
fix(ci): skip deploy-preview for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   deploy-preview:
     needs: [build, cli]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

- Skip `deploy-preview` CI job for Dependabot PRs by adding `github.actor != 'dependabot[bot]'` condition
- GitHub Actions security policy prevents repository secrets from being exposed to Dependabot-triggered workflows
- The `CONVEX_DEPLOY_KEY_DEV` secret resolves to empty on Dependabot PRs, causing `npx convex deploy` to fail with exit code 1

## Root Cause

GitHub Actions does not expose repository secrets to workflows triggered by Dependabot pull requests. The `deploy-preview` job ran on ALL PRs, including Dependabot PRs where `secrets.CONVEX_DEPLOY_KEY_DEV` is unavailable.

## Fix

Added `github.actor != 'dependabot[bot]'` to the `deploy-preview` job's `if` condition. This skips the Convex deploy for Dependabot PRs while leaving all other PR deploys and the main branch deploy job unaffected.

## Test plan

- [x] YAML syntax validated
- [x] All 266 tests pass (`npm test`)
- [x] Other CI jobs (`build`, `cli`, `e2e`, `deploy`) unaffected
- [x] Verified via CI logs: run 24253264405 (Dependabot) has empty secret, run 24253826624 (regular PR) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)