### PR TITLE
fix: use ConvexError for client-facing publish errors

### DIFF
--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { mutation, query, internalMutation } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
@@ -34,7 +34,7 @@ function throwIfDepErrors(
     errors.push(`No matching version for role dependency of '${slug}': ${roleVersionMismatch.join(", ")}`);
   }
   if (errors.length > 0) {
-    throw new Error(`Failed to publish role '${slug}': ${errors.join(". ")}`);
+    throw new ConvexError(`Failed to publish role '${slug}': ${errors.join(". ")}`);
   }
 }
 
@@ -455,11 +455,11 @@ export const publish = mutation({
     validateRoleFiles(args.files);
 
     const userId = await getAuthUserId(ctx);
-    if (!userId) throw new Error("Not authenticated");
+    if (!userId) throw new ConvexError("Not authenticated");
 
     const user = await ctx.db.get(userId);
-    if (!user) throw new Error("User not found");
-    if (user.deactivatedAt) throw new Error("Account is deactivated");
+    if (!user) throw new ConvexError("User not found");
+    if (user.deactivatedAt) throw new ConvexError("Account is deactivated");
 
     const now = Date.now();
 
@@ -564,10 +564,10 @@ export const publish = mutation({
 
     if (role) {
       if (role.ownerUserId !== user._id) {
-        throw new Error("You do not own this role");
+        throw new ConvexError("You do not own this role");
       }
       if (role.softDeletedAt) {
-        throw new Error("Role has been deleted");
+        throw new ConvexError("Role has been deleted");
       }
     } else {
       const roleId = await ctx.db.insert("roles", {
@@ -601,12 +601,12 @@ export const publish = mutation({
         q.eq("roleId", role!._id).eq("version", version),
       )
       .first();
-    if (existing) throw new Error(`Version ${version} already exists`);
+    if (existing) throw new ConvexError(`Version ${version} already exists`);
 
     // Check version is greater than latest
     if (latestVer) {
       if (compareVersions(parseVersion(version), parseVersion(latestVer)) <= 0) {
-        throw new Error(
+        throw new ConvexError(
           `Version ${version} must be greater than the latest version ${latestVer}`,
         );
       }


### PR DESCRIPTION
## Summary

- **Bug fix**: Convex strips plain `Error` messages from client-facing mutations as a security feature, so the improved error messages from PR #186 were invisible to web UI users (they saw generic "Server Error" instead)
- Changed 8 `throw new Error()` → `throw new ConvexError()` in `convex/roles.ts`: the `throwIfDepErrors` helper and all error throws in the `publish` mutation (auth, ownership, deletion, version checks)
- `publishInternal` (internal mutation) left unchanged — its errors are caught by the httpAction which accesses `e.message` directly

## Test plan

- [x] 266/266 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Verified `ConvexError(string).message === string` (httpAction catch blocks still work)
- [ ] Manual: publish a role with a missing dependency via web UI → should see the full error message instead of "Server Error"

## Follow-up (out of scope)

- `softDelete` and `restore` mutations in `convex/roles.ts` have the same bug (plain `Error` in client-facing mutations)
- `convex/skills.ts`, `convex/agents.ts`, `convex/integrations.ts`, `convex/memories.ts` have the same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)