### PR TITLE
fix: use ConvexError in agents/integrations/memories publish mutations

### DIFF
--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { mutation, query, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
@@ -334,11 +334,11 @@ export const publish = mutation({
     validateAgentFiles(args.files);
 
     const userId = await getAuthUserId(ctx);
-    if (!userId) throw new Error("Not authenticated");
+    if (!userId) throw new ConvexError("Not authenticated");
 
     const user = await ctx.db.get(userId);
-    if (!user) throw new Error("User not found");
-    if (user.deactivatedAt) throw new Error("Account is deactivated");
+    if (!user) throw new ConvexError("User not found");
+    if (user.deactivatedAt) throw new ConvexError("Account is deactivated");
 
     const now = Date.now();
 
@@ -361,10 +361,10 @@ export const publish = mutation({
 
     if (agent) {
       if (agent.ownerUserId !== user._id) {
-        throw new Error("You do not own this agent");
+        throw new ConvexError("You do not own this agent");
       }
       if (agent.softDeletedAt) {
-        throw new Error("Agent has been deleted");
+        throw new ConvexError("Agent has been deleted");
       }
     } else {
       const agentId = await ctx.db.insert("agents", {
@@ -398,13 +398,13 @@ export const publish = mutation({
         q.eq("agentId", agent!._id).eq("version", version),
       )
       .first();
-    if (existing) throw new Error(`Version ${version} already exists`);
+    if (existing) throw new ConvexError(`Version ${version} already exists for agent '${args.slug}'`);
 
     // Check version is greater than latest
     if (latestVer) {
       if (compareVersions(parseVersion(version), parseVersion(latestVer)) <= 0) {
-        throw new Error(
-          `Version ${version} must be greater than the latest version ${latestVer}`,
+        throw new ConvexError(
+          `Version ${version} must be greater than the latest version ${latestVer} for agent '${args.slug}'`,
         );
       }
     }

--- a/convex/integrations.ts
+++ b/convex/integrations.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { mutation, query, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
@@ -331,11 +331,11 @@ export const publish = mutation({
     validateIntegrationFiles(args.files);
 
     const userId = await getAuthUserId(ctx);
-    if (!userId) throw new Error("Not authenticated");
+    if (!userId) throw new ConvexError("Not authenticated");
 
     const user = await ctx.db.get(userId);
-    if (!user) throw new Error("User not found");
-    if (user.deactivatedAt) throw new Error("Account is deactivated");
+    if (!user) throw new ConvexError("User not found");
+    if (user.deactivatedAt) throw new ConvexError("Account is deactivated");
 
     const now = Date.now();
 
@@ -356,10 +356,10 @@ export const publish = mutation({
 
     if (integration) {
       if (integration.ownerUserId !== user._id) {
-        throw new Error("You do not own this integration");
+        throw new ConvexError("You do not own this integration");
       }
       if (integration.softDeletedAt) {
-        throw new Error("Integration has been deleted");
+        throw new ConvexError("Integration has been deleted");
       }
     } else {
       const integrationId = await ctx.db.insert("integrations", {
@@ -391,12 +391,12 @@ export const publish = mutation({
         q.eq("integrationId", integration!._id).eq("version", version),
       )
       .first();
-    if (existing) throw new Error(`Version ${version} already exists`);
+    if (existing) throw new ConvexError(`Version ${version} already exists for integration '${args.slug}'`);
 
     if (latestVer) {
       if (compareVersions(parseVersion(version), parseVersion(latestVer)) <= 0) {
-        throw new Error(
-          `Version ${version} must be greater than the latest version ${latestVer}`,
+        throw new ConvexError(
+          `Version ${version} must be greater than the latest version ${latestVer} for integration '${args.slug}'`,
         );
       }
     }

--- a/convex/memories.ts
+++ b/convex/memories.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { mutation, query, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
@@ -333,11 +333,11 @@ export const publish = mutation({
     validateMemoryFiles(args.files);
 
     const userId = await getAuthUserId(ctx);
-    if (!userId) throw new Error("Not authenticated");
+    if (!userId) throw new ConvexError("Not authenticated");
 
     const user = await ctx.db.get(userId);
-    if (!user) throw new Error("User not found");
-    if (user.deactivatedAt) throw new Error("Account is deactivated");
+    if (!user) throw new ConvexError("User not found");
+    if (user.deactivatedAt) throw new ConvexError("Account is deactivated");
 
     const now = Date.now();
 
@@ -360,10 +360,10 @@ export const publish = mutation({
 
     if (memory) {
       if (memory.ownerUserId !== user._id) {
-        throw new Error("You do not own this memory");
+        throw new ConvexError("You do not own this memory");
       }
       if (memory.softDeletedAt) {
-        throw new Error("Memory has been deleted");
+        throw new ConvexError("Memory has been deleted");
       }
     } else {
       const memoryId = await ctx.db.insert("memories", {
@@ -397,13 +397,13 @@ export const publish = mutation({
         q.eq("memoryId", memory!._id).eq("version", version),
       )
       .first();
-    if (existing) throw new Error(`Version ${version} already exists`);
+    if (existing) throw new ConvexError(`Version ${version} already exists for memory '${args.slug}'`);
 
     // Check version is greater than latest
     if (latestVer) {
       if (compareVersions(parseVersion(version), parseVersion(latestVer)) <= 0) {
-        throw new Error(
-          `Version ${version} must be greater than the latest version ${latestVer}`,
+        throw new ConvexError(
+          `Version ${version} must be greater than the latest version ${latestVer} for memory '${args.slug}'`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- Apply the same Error → ConvexError fix from PR #187 (roles.ts) and PR #188 (skills.ts) to the remaining 3 files
- Convert 7 throw statements per file (21 total) in client-facing publish mutations from Error to ConvexError
- Enhanced version error messages to include entity slug for better debugging context
- publishInternal mutations left unchanged (httpAction catches e.message)
- No throwIfDepErrors helper needed (these entities have no dependency validation)

Completes the Error → ConvexError migration across all 5 publish mutations: roles.ts (#187), skills.ts (#188), agents.ts + integrations.ts + memories.ts (this PR).

## Test plan
- [x] All 266 existing tests pass
- [x] TypeScript compiles cleanly
- [x] Code review: NO_FURTHER_IMPROVEMENTS
- [x] Code simplifier: NO_FURTHER_IMPROVEMENTS
- [x] QA verification: all 9 acceptance criteria pass (verified per-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)